### PR TITLE
Add comic panel camera mode

### DIFF
--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -16,6 +16,21 @@ def main() -> None:
     parser.add_argument("folder", help="Input folder with images and audio")
     parser.add_argument("--tesseract", help="Path to Tesseract binary")
     parser.add_argument("--magick", help="Path to ImageMagick binary")
+    parser.add_argument(
+        "--mode",
+        choices=["classic", "panels"],
+        default="classic",
+        help=(
+            "classic: dotychczasowy montaż; panels: ruch kamery po panelach komiksu"
+        ),
+    )
+    parser.add_argument(
+        "--debug-panels",
+        action="store_true",
+        help=(
+            "Tryb debug – zapisuje plik panels_debug.jpg z wykrytymi ramkami i kończy działanie."
+        ),
+    )
     args = parser.parse_args()
 
     if args.magick:
@@ -25,7 +40,43 @@ def main() -> None:
         pytesseract.pytesseract.tesseract_cmd = args.tesseract
 
     verify_tesseract_available()
-    make_filmstrip(args.folder)
+
+    if args.debug_panels:
+        from .panels import debug_detect_panels
+
+        debug_detect_panels(args.folder)
+        print("✅ Zapisano panels_debug.jpg – sprawdź kolejność ramek.")
+        return
+
+    if args.mode == "panels":
+        from .builder import make_panels_cam_clip
+        from moviepy.editor import AudioFileClip
+
+        # wybieramy pierwsze zdjęcie z folderu
+        images = [
+            f
+            for f in os.listdir(args.folder)
+            if os.path.splitext(f)[1].lower() in {".jpg", ".jpeg", ".png"}
+        ]
+        if not images:
+            raise FileNotFoundError("Brak obrazów w folderze.")
+        image_path = os.path.join(args.folder, images[0])
+        clip = make_panels_cam_clip(image_path, target_size=(1080, 1920))
+
+        # audio (opcjonalnie)
+        audios = [
+            f
+            for f in os.listdir(args.folder)
+            if os.path.splitext(f)[1].lower() in {".mp3", ".wav", ".m4a"}
+        ]
+        if audios:
+            clip = clip.set_audio(
+                AudioFileClip(os.path.join(args.folder, audios[0]))
+            )
+        out_path = os.path.join(args.folder, "final_video.mp4")
+        clip.write_videofile(out_path, fps=30, codec="libx264")
+    else:
+        make_filmstrip(args.folder)
 
 
 if __name__ == "__main__":

--- a/ken_burns_reel/panels.py
+++ b/ken_burns_reel/panels.py
@@ -1,0 +1,74 @@
+from typing import List, Tuple
+import cv2
+import numpy as np
+from PIL import Image
+
+Box = Tuple[int, int, int, int]
+
+def detect_panels(img: Image.Image, min_area_ratio: float = 0.03, white_thr: int = 235) -> List[Box]:
+    rgb = np.array(img.convert("RGB"))
+    lab = cv2.cvtColor(rgb, cv2.COLOR_RGB2LAB)
+    L = lab[:, :, 0]
+    _, mask_white = cv2.threshold(L, white_thr, 255, cv2.THRESH_BINARY)
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (7, 7))
+    gutters = cv2.morphologyEx(mask_white, cv2.MORPH_CLOSE, kernel, iterations=1)
+    panels_mask = cv2.bitwise_not(gutters)
+    kernel2 = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+    panels_mask = cv2.morphologyEx(panels_mask, cv2.MORPH_OPEN, kernel2, iterations=1)
+    num, labels, stats, _ = cv2.connectedComponentsWithStats(panels_mask, connectivity=8)
+    H, W = panels_mask.shape
+    min_area = int(min_area_ratio * W * H)
+    boxes: List[Box] = []
+    for i in range(1, num):
+        x, y, w, h, area = stats[i]
+        if area < min_area:
+            continue
+        ar = w / max(1, h)
+        if 0.3 <= ar <= 4.0:
+            boxes.append((int(x), int(y), int(w), int(h)))
+    return boxes
+
+def order_panels_lr_tb(boxes: List[Box], row_tol: int = 40) -> List[Box]:
+    boxes = sorted(boxes, key=lambda b: (b[1], b[0]))
+    rows: List[List[Box]] = []
+    for b in boxes:
+        placed = False
+        for row in rows:
+            if abs(row[0][1] - b[1]) <= row_tol:
+                row.append(b)
+                placed = True
+                break
+        if not placed:
+            rows.append([b])
+    out: List[Box] = []
+    for row in rows:
+        out.extend(sorted(row, key=lambda b: b[0]))
+    return out
+
+def debug_detect_panels(folder: str) -> None:
+    import os
+
+    images = [
+        f
+        for f in os.listdir(folder)
+        if os.path.splitext(f)[1].lower() in {".jpg", ".jpeg", ".png"}
+    ]
+    if not images:
+        raise FileNotFoundError("Brak obrazów do debugowania.")
+    image_path = os.path.join(folder, images[0])
+    img = Image.open(image_path)
+    boxes = order_panels_lr_tb(detect_panels(img))
+    vis = np.array(img.convert("RGB")).copy()
+    for i, (x, y, w, h) in enumerate(boxes):
+        cv2.rectangle(vis, (x, y), (x + w, y + h), (0, 0, 255), 3)
+        cv2.putText(
+            vis,
+            str(i + 1),
+            (x + 10, y + 40),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            1,
+            (255, 0, 0),
+            2,
+        )
+    out_path = os.path.join(folder, "panels_debug.jpg")
+    cv2.imwrite(out_path, cv2.cvtColor(vis, cv2.COLOR_RGB2BGR))


### PR DESCRIPTION
## Summary
- add `--mode` CLI flag and optional panel detection debug path
- implement panel-based camera animation for comic pages
- introduce helper module for detecting and ordering panels

## Testing
- `PYTHONPATH=$PWD pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689696687a888321b20e711bfd922e1c