### PR TITLE
feat(panels): sequence across images + CLI dwell/travel/xfade; fix VideoClip frame generator

### DIFF
--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -24,6 +24,9 @@ def main() -> None:
             "classic: dotychczasowy montaż; panels: ruch kamery po panelach komiksu"
         ),
     )
+    parser.add_argument("--dwell", type=float, default=1.0, help="Czas zatrzymania na panelu (s)")
+    parser.add_argument("--travel", type=float, default=0.6, help="Czas przejazdu między panelami (s)")
+    parser.add_argument("--xfade", type=float, default=0.4, help="Crossfade między stronami (s)")
     parser.add_argument(
         "--debug-panels",
         action="store_true",
@@ -49,21 +52,27 @@ def main() -> None:
         return
 
     if args.mode == "panels":
-        from .builder import make_panels_cam_clip
+        from .builder import make_panels_cam_sequence
         from moviepy.editor import AudioFileClip
 
-        # wybieramy pierwsze zdjęcie z folderu
         images = [
-            f
+            os.path.join(args.folder, f)
             for f in os.listdir(args.folder)
             if os.path.splitext(f)[1].lower() in {".jpg", ".jpeg", ".png"}
         ]
+        images.sort(key=lambda s: os.path.basename(s).lower())
         if not images:
             raise FileNotFoundError("Brak obrazów w folderze.")
-        image_path = os.path.join(args.folder, images[0])
-        clip = make_panels_cam_clip(image_path, target_size=(1080, 1920))
 
-        # audio (opcjonalnie)
+        clip = make_panels_cam_sequence(
+            images,
+            target_size=(1080, 1920),
+            fps=30,
+            dwell=args.dwell,
+            travel=args.travel,
+            xfade=args.xfade,
+        )
+
         audios = [
             f
             for f in os.listdir(args.folder)

--- a/ken_burns_reel/builder.py
+++ b/ken_burns_reel/builder.py
@@ -109,9 +109,33 @@ def make_panels_cam_clip(
             acc += dur
         return base.get_frame(0)
 
-    anim = base.set_duration(total).fl_image(lambda _: None)
-    anim = anim.set_make_frame(make_frame)
+    from moviepy.video.VideoClip import VideoClip
+
+    anim = VideoClip(make_frame=make_frame, duration=total).set_fps(fps)
     return anim
+
+
+def make_panels_cam_sequence(
+    image_paths: List[str],
+    target_size=(1080, 1920),
+    fps: int = 30,
+    dwell: float = 1.0,
+    travel: float = 0.6,
+    xfade: float = 0.4,
+):
+    """
+    Buduje jeden film, sklejając panel-camera clippy dla wszystkich stron.
+    """
+    if not image_paths:
+        raise ValueError("make_panels_cam_sequence: empty image_paths")
+
+    clips = [
+        make_panels_cam_clip(p, target_size=target_size, fps=fps, dwell=dwell, travel=travel)
+        for p in image_paths
+    ]
+    # Crossfade między stronami
+    final = concatenate_videoclips(clips, method="compose", padding=-xfade)
+    return final
 
 
 ScreenSize = Tuple[int, int]


### PR DESCRIPTION
## Summary
- animate panels using `VideoClip` frame generator
- add `make_panels_cam_sequence` to stitch panels across multiple images
- expose `--dwell`, `--travel`, and `--xfade` CLI options for panel mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ken_burns_reel')*
- `python -m ken_burns_reel . --debug-panels` *(fails: No module named 'moviepy.editor')*
- `python -m ken_burns_reel . --mode panels` *(fails: No module named 'moviepy.editor')*

## Post-merge
```bash
git pull origin main
python -m ken_burns_reel . --debug-panels
python -m ken_burns_reel . --mode panels --dwell 1.1 --travel 0.6 --xfade 0.4
```

------
https://chatgpt.com/codex/tasks/task_e_68969aa62f9083219f64176f917b6a3b