### PR TITLE
Hardening and hygiene updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ pip install -r requirements.txt
 - [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) — wymagany do ekstrakcji tekstu z obrazów (OCR)
 - FFmpeg — wymagany przez MoviePy do renderowania wideo
 
+### Konfiguracja binarek
+
+Ścieżki do narzędzi zewnętrznych są rozwiązywane automatycznie w kolejności:
+
+1. Parametry CLI `--magick` / `--tesseract`.
+2. Zmienne środowiskowe `IMAGEMAGICK_BINARY` / `TESSERACT_BINARY`.
+3. Ustawienia bibliotek (MoviePy, pytesseract).
+4. Wyszukanie w `PATH` systemowym.
+
+Jeśli narzędzie nie zostanie znalezione, napisy/OCR mogą zostać pominięte.
+Na Windows upewnij się, że:
+
+- katalog ImageMagick zawiera poprawny plik `colors.xml`,
+- `tesseract.exe` znajduje się w `PATH` lub podaj do niego pełną ścieżkę.
+
 ---
 
 ## 📖 Użycie

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 import argparse
 import os
 
-import moviepy.config as mpyconf
-import pytesseract
-
+from .bin_config import resolve_imagemagick, resolve_tesseract
 from .builder import make_filmstrip
 from .ocr import verify_tesseract_available
 
@@ -36,12 +34,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.magick:
-        os.environ["IMAGEMAGICK_BINARY"] = args.magick
-        mpyconf.change_settings({"IMAGEMAGICK_BINARY": args.magick})
-    if args.tesseract:
-        pytesseract.pytesseract.tesseract_cmd = args.tesseract
-
+    resolve_imagemagick(args.magick)
+    resolve_tesseract(args.tesseract)
     verify_tesseract_available()
 
     if args.debug_panels:

--- a/ken_burns_reel/bin_config.py
+++ b/ken_burns_reel/bin_config.py
@@ -1,0 +1,76 @@
+"""Helpers to resolve external binary paths.
+
+This module centralizes discovery of ImageMagick and Tesseract executables
+without requiring hard coded paths. Resolution order follows CLI arguments,
+environment variables, existing library configuration and finally a search on
+``PATH``.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from typing import Optional
+
+import moviepy.config as mpyconf
+import pytesseract
+
+
+def _validate_binary(path: str | None) -> Optional[str]:
+    """Return *path* if it points to an existing executable."""
+    if not path:
+        return None
+    if os.path.isfile(path) or shutil.which(path):
+        return path
+    return None
+
+
+def resolve_imagemagick(cli_path: str | None = None) -> Optional[str]:
+    """Resolve path to ImageMagick ``magick`` executable.
+
+    Resolution order:
+    1. explicit ``cli_path`` argument (e.g. ``--magick``)
+    2. ``IMAGEMAGICK_BINARY`` environment variable
+    3. MoviePy configuration
+    4. ``magick`` discovered on ``PATH``
+    The returned path is validated and applied to MoviePy configuration and
+    ``os.environ``. Returns ``None`` if no candidate is found.
+    """
+    candidates = [
+        cli_path,
+        os.environ.get("IMAGEMAGICK_BINARY"),
+        getattr(mpyconf, "IMAGEMAGICK_BINARY", None),
+        shutil.which("magick"),
+    ]
+    for cand in candidates:
+        path = _validate_binary(cand)
+        if path:
+            os.environ["IMAGEMAGICK_BINARY"] = path
+            try:
+                mpyconf.change_settings({"IMAGEMAGICK_BINARY": path})
+            except Exception:
+                pass
+            return path
+    return None
+
+
+def resolve_tesseract(cli_path: str | None = None) -> Optional[str]:
+    """Resolve path to the Tesseract binary.
+
+    Resolution order mirrors :func:`resolve_imagemagick` but for Tesseract.
+    The discovered path is stored in ``pytesseract.pytesseract.tesseract_cmd``
+    and ``TESSERACT_BINARY`` environment variable. Returns ``None`` if the
+    executable cannot be located.
+    """
+    candidates = [
+        cli_path,
+        os.environ.get("TESSERACT_BINARY"),
+        getattr(pytesseract.pytesseract, "tesseract_cmd", None),
+        shutil.which("tesseract"),
+    ]
+    for cand in candidates:
+        path = _validate_binary(cand)
+        if path:
+            os.environ["TESSERACT_BINARY"] = path
+            pytesseract.pytesseract.tesseract_cmd = path
+            return path
+    return None

--- a/ken_burns_reel/captions.py
+++ b/ken_burns_reel/captions.py
@@ -1,0 +1,58 @@
+"""Caption rendering utilities."""
+from __future__ import annotations
+
+from typing import Tuple, Optional
+import re
+
+from moviepy.editor import CompositeVideoClip, TextClip
+
+CAPTION_MAXLEN = 120
+CAPTION_MIN_ALNUM = 3
+
+
+def sanitize_caption(text: str) -> str:
+    text = re.sub(r"[\\]+", "", text or "")
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:CAPTION_MAXLEN]
+
+
+def is_caption_meaningful(text: str) -> bool:
+    return sum(ch.isalnum() for ch in (text or "")) >= CAPTION_MIN_ALNUM
+
+
+def render_caption_clip(
+    text: str, size: Tuple[int, int], margin: int = 50, method: str = "label"
+) -> Optional[TextClip]:
+    """Create a TextClip for *text* or return ``None`` if rendering fails."""
+    text = sanitize_caption(text)
+    if not is_caption_meaningful(text):
+        return None
+    W, _ = size
+    try:
+        clip = TextClip(
+            text,
+            fontsize=50,
+            color="white",
+            stroke_color="black",
+            stroke_width=2,
+            method=method,
+            size=(W - 2 * margin, None),
+        )
+    except Exception as e:
+        if method != "label":
+            return render_caption_clip(text, size, margin, method="label")
+        print(f"⚠️ Unable to render caption: {e}")
+        return None
+    return clip
+
+
+def overlay_caption(
+    clip, text: str, size: Tuple[int, int], margin: int = 50, method: str = "label"
+):
+    """Overlay *text* caption onto *clip* if possible."""
+    txt = render_caption_clip(text, size, margin, method)
+    if txt is None:
+        return clip
+    W, H = size
+    txt = txt.set_position(("center", H - 200)).set_duration(clip.duration).fadein(0.3).fadeout(0.3)
+    return CompositeVideoClip([clip, txt], size=size)

--- a/ken_burns_reel/focus.py
+++ b/ken_burns_reel/focus.py
@@ -6,6 +6,7 @@ from typing import Tuple
 import numpy as np
 import cv2
 from PIL import Image
+import logging
 
 
 def detect_focus_point(img: Image.Image) -> Tuple[int, int]:
@@ -25,6 +26,12 @@ def detect_focus_point(img: Image.Image) -> Tuple[int, int]:
     brightness = gray.astype(float)
     y_indices, x_indices = np.indices(brightness.shape)
     total = brightness.sum()
-    x = int((x_indices * brightness).sum() / total)
-    y = int((y_indices * brightness).sum() / total)
+    eps = 1e-6
+    if total <= eps:
+        h, w = gray.shape
+        logging.warning("detect_focus_point: black frame – using centre")
+        return (w // 2, h // 2)
+    den = max(eps, total)
+    x = int((x_indices * brightness).sum() / den)
+    y = int((y_indices * brightness).sum() / den)
     return (x, y)

--- a/ken_burns_reel/ocr.py
+++ b/ken_burns_reel/ocr.py
@@ -1,29 +1,27 @@
 """OCR helpers."""
 from __future__ import annotations
 
-import os
 from typing import Tuple
 
 from PIL import Image
 import pytesseract
-from shutil import which
 
-from .utils import sanitize_caption
+from .bin_config import resolve_tesseract
+from .captions import sanitize_caption
 
 
 def extract_caption(img_path: str) -> str:
     """Extract text from an image using pytesseract."""
-    img = Image.open(img_path)
-    text = pytesseract.image_to_string(img)
+    with Image.open(img_path) as img:
+        text = pytesseract.image_to_string(img)
     return sanitize_caption(text)
 
 
 def verify_tesseract_available() -> None:
-    """Ensure tesseract binary is available or exit."""
-    binary = os.environ.get("TESSERACT_BINARY") or pytesseract.pytesseract.tesseract_cmd
-    pytesseract.pytesseract.tesseract_cmd = binary
-    if not os.path.isfile(binary) and not which(binary):
+    """Ensure tesseract binary is available or raise an error."""
+    binary = resolve_tesseract()
+    if not binary:
         raise EnvironmentError(
-            f"Tesseract OCR binary not found at: {binary}. Install Tesseract or update configuration."
+            "Tesseract OCR binary not found. Install Tesseract or update configuration."
         )
     print(f"✅ Tesseract OCR: {binary}")

--- a/ken_burns_reel/panels.py
+++ b/ken_burns_reel/panels.py
@@ -56,9 +56,9 @@ def debug_detect_panels(folder: str) -> None:
     if not images:
         raise FileNotFoundError("Brak obrazów do debugowania.")
     image_path = os.path.join(folder, images[0])
-    img = Image.open(image_path)
-    boxes = order_panels_lr_tb(detect_panels(img))
-    vis = np.array(img.convert("RGB")).copy()
+    with Image.open(image_path) as img:
+        boxes = order_panels_lr_tb(detect_panels(img))
+        vis = np.array(img.convert("RGB")).copy()
     for i, (x, y, w, h) in enumerate(boxes):
         cv2.rectangle(vis, (x, y), (x + w, y + h), (0, 0, 255), 3)
         cv2.putText(

--- a/ken_burns_reel/utils.py
+++ b/ken_burns_reel/utils.py
@@ -1,59 +1,11 @@
 """Utility helpers for video creation."""
 from __future__ import annotations
 
-from typing import Tuple
-
-import re
 from typing import TYPE_CHECKING
 from PIL import Image
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from moviepy.editor import CompositeVideoClip, ImageClip, TextClip
-
-# Caption configuration
-CAPTION_MAXLEN = 120
-CAPTION_MIN_ALNUM = 3
-
-
-def sanitize_caption(text: str) -> str:
-    text = re.sub(r"[\\]+", "", text or "")
-    text = re.sub(r"\s+", " ", text).strip()
-    return text[:CAPTION_MAXLEN]
-
-
-def is_caption_meaningful(text: str) -> bool:
-    return sum(ch.isalnum() for ch in (text or "")) >= CAPTION_MIN_ALNUM
-
-
-def overlay_caption(clip: "ImageClip", text: str, size: Tuple[int, int]) -> "ImageClip":
-    """Overlay text caption onto a clip."""
-    from moviepy.editor import CompositeVideoClip, ImageClip, TextClip
-    text = sanitize_caption(text)
-    if not is_caption_meaningful(text):
-        return clip
-    W, H = size
-    try:
-        txt = TextClip(
-            text,
-            fontsize=50,
-            color="white",
-            stroke_color="black",
-            stroke_width=2,
-            method="caption",
-            size=(W - 100, None),
-        )
-    except Exception as e:
-        print(f"⚠️ TextClip fallback to 'label': {e}")
-        txt = TextClip(
-            text,
-            fontsize=50,
-            color="white",
-            stroke_color="black",
-            stroke_width=2,
-            method="label",
-        )
-    txt = txt.set_position(("center", H - 200)).set_duration(clip.duration).fadein(0.3).fadeout(0.3)
-    return CompositeVideoClip([clip, txt], size=size)
+    from moviepy.editor import ImageClip
 
 
 def smart_crop(img: Image.Image, target_w: int, target_h: int) -> Image.Image:

--- a/tests/test_builder_sequence_basic.py
+++ b/tests/test_builder_sequence_basic.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image, ImageDraw
+import soundfile as sf
+
+from ken_burns_reel.bin_config import resolve_imagemagick, resolve_tesseract
+from ken_burns_reel.builder import make_filmstrip, make_panels_cam_sequence
+
+IM = resolve_imagemagick()
+TE = resolve_tesseract()
+
+pytestmark = pytest.mark.skipif(
+    IM is None or TE is None, reason="requires ImageMagick and Tesseract"
+)
+
+
+def _create_image(path: Path) -> None:
+    img = Image.new("RGB", (400, 400), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([50, 50, 350, 350], outline="black", width=5)
+    img.save(path)
+
+
+def _create_audio(path: Path, duration: float = 2.0, sr: int = 22050) -> None:
+    data = np.zeros(int(sr * duration), dtype=np.float32)
+    sf.write(path, data, sr)
+
+
+def test_builder_and_panels_sequence(tmp_path: Path) -> None:
+    for i in range(2):
+        _create_image(tmp_path / f"img{i}.png")
+    _create_audio(tmp_path / "audio.wav")
+
+    make_filmstrip(str(tmp_path))
+    out = tmp_path / "final_video.mp4"
+    assert out.exists() and out.stat().st_size > 0
+
+    clip = make_panels_cam_sequence(
+        [str(tmp_path / f"img{i}.png") for i in range(2)],
+        target_size=(64, 64),
+        dwell=0.1,
+        travel=0.1,
+    )
+    out2 = tmp_path / "panels.mp4"
+    clip.write_videofile(str(out2), fps=24, codec="libx264")
+    assert out2.exists() and out2.stat().st_size > 0

--- a/tests/test_focus_guard.py
+++ b/tests/test_focus_guard.py
@@ -1,0 +1,8 @@
+from PIL import Image
+
+from ken_burns_reel.focus import detect_focus_point
+
+
+def test_black_frame_returns_center():
+    img = Image.new("RGB", (100, 100), "black")
+    assert detect_focus_point(img) == (50, 50)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,0 +1,11 @@
+from ken_burns_reel.transitions import slide_transition
+from moviepy.editor import ColorClip
+
+
+def test_slide_transition_basic():
+    clip1 = ColorClip(size=(100, 100), color=(255, 0, 0)).set_duration(1).set_fps(24)
+    clip2 = ColorClip(size=(100, 100), color=(0, 255, 0)).set_duration(1).set_fps(24)
+    trans = slide_transition(clip1, clip2, 0.5, (100, 100), 24)
+    assert abs(trans.duration - 0.5) < 1e-6
+    frame = trans.get_frame(0.25)
+    assert frame.shape[:2] == (100, 100)


### PR DESCRIPTION
## Summary
- add binary path resolution helpers for ImageMagick and Tesseract and use them across the CLI
- centralize caption rendering utilities and de-duplicate implementations
- guard focus detection against black frames and use context managers for image files
- add basic builder, transition and focus tests and document binary setup

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a8ba285c832198c5e1b41a6abc71