### PR TITLE
Add audio fades and beat alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .env
 .DS_Store
 .pytest_cache/
+.venv/

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -26,3 +26,15 @@ def test_audio_fades_present():
     arr1 = clip1.to_soundarray(fps=sr)
     arr2 = clip2.to_soundarray(fps=sr)
     assert arr1[-1, 0] < 1.0 and arr2[0, 0] < 1.0
+
+
+def test_final_audio_fade_rms():
+    sr = 1000
+    audio = AudioClip(lambda t: [1.0], duration=1, fps=sr)
+    audio = audio_fadein(audio, 0.15)
+    audio = audio_fadeout(audio, 0.15)
+    arr = audio.to_soundarray(fps=sr)
+    rms_start = np.sqrt(np.mean(arr[:150, 0] ** 2))
+    rms_mid = np.sqrt(np.mean(arr[400:600, 0] ** 2))
+    rms_end = np.sqrt(np.mean(arr[-150:, 0] ** 2))
+    assert rms_start < rms_mid and rms_end < rms_mid

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,38 @@
+import numpy as np
+from PIL import Image
+
+from ken_burns_reel.builder import make_panels_cam_sequence
+
+
+def make_img(path):
+    arr = np.zeros((100, 100, 3), dtype=np.uint8)
+    Image.fromarray(arr).save(path)
+
+
+def test_align_beat_snaps_start(tmp_path):
+    img1 = tmp_path / 'a.png'
+    img2 = tmp_path / 'b.png'
+    make_img(img1)
+    make_img(img2)
+    beats = [0.0, 1.05, 2.0]
+    clip = make_panels_cam_sequence(
+        [str(img1), str(img2)],
+        target_size=(64, 64),
+        fps=30,
+        xfade=0.0,
+        align_beat=True,
+        beat_times=beats,
+    )
+    clip_no = make_panels_cam_sequence(
+        [str(img1), str(img2)],
+        target_size=(64, 64),
+        fps=30,
+        xfade=0.0,
+        align_beat=False,
+    )
+    start_aligned = clip.clips[1].start
+    start_plain = clip_no.clips[1].start
+    diff_aligned = abs(start_aligned - beats[1])
+    diff_plain = abs(start_plain - beats[1])
+    assert diff_aligned <= 0.08
+    assert diff_aligned < diff_plain


### PR DESCRIPTION
## Summary
- add beat extraction and audio fading in CLI panel mode
- snap panel-camera pages to nearby beats with crossfades
- apply fade-in/out to final filmstrip audio and add regression tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b33bc3d08321a7aa1b8f77989d7a