### PR TITLE
feat: audio fitting, dwell modes, and OCR cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ cd Automatyczne-generowanie-video-z-obrazkow
 
 2. **Instalacja zależności**
 ```bash
-pip install -r requirements.txt
+pip install -e .
 ```
 
 3. **Wymagania dodatkowe**
 - [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) — wymagany do ekstrakcji tekstu z obrazów (OCR)
+- [ImageMagick](https://imagemagick.org) — renderowanie podpisów
 - FFmpeg — wymagany przez MoviePy do renderowania wideo
 
 ### Konfiguracja binarek
@@ -72,18 +73,13 @@ Na Windows upewnij się, że:
 python -m ken_burns_reel <ścieżka_do_folderu_z_obrazkami> --output output.mp4
 ```
 
-### 2. Skrypt przewijania + audio
-```bash
-python ken_burns_scroll_audio.py --input obrazy/ --audio muzyka.mp3 --output wideo.mp4
-```
-
 **Najważniejsze opcje CLI**:
-- `--input` — katalog z obrazami
-- `--audio` — ścieżka do pliku audio
-- `--output` — nazwa pliku wynikowego
-- `--duration` — czas trwania wideo w sekundach
-- `--zoom` — poziom powiększenia efektu Ken Burns
-- `--scroll` — włączenie przewijania obrazu
+- `--audio-fit {trim,silence,loop}` — dopasowanie długości audio do wideo
+- `--dwell-mode {first,each}` — zatrzymanie tylko na pierwszym panelu lub na każdym
+- `--align-beat` — dociąga start stron do beatu (±0.08 s, bez ujemnych segmentów)
+- `--debug-panels` — zapisuje podgląd wykrytych paneli i kończy działanie
+
+Czas trwania filmu wynika z sumy klipów wideo, a audio jest dostosowywane zgodnie z `--audio-fit`.
 
 ---
 

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -50,6 +50,18 @@ def main() -> None:
             "Tryb debug – zapisuje plik panels_debug.jpg z wykrytymi ramkami i kończy działanie."
         ),
     )
+    parser.add_argument(
+        "--audio-fit",
+        choices=["trim", "silence", "loop"],
+        default="trim",
+        help="Jak dopasować audio do długości wideo",
+    )
+    parser.add_argument(
+        "--dwell-mode",
+        choices=["first", "each"],
+        default="first",
+        help="Na ilu panelach zatrzymywać się w pełni",
+    )
     args = parser.parse_args()
 
     resolve_imagemagick(args.magick)
@@ -102,16 +114,14 @@ def main() -> None:
             dwell_scale=args.dwell_scale,
             align_beat=args.align_beat,
             beat_times=beat_times,
+            audio_path=audio_path,
+            audio_fit=args.audio_fit,
+            dwell_mode=args.dwell_mode,
         )
-        if audio_path:
-            audioclip = AudioFileClip(audio_path)
-            audioclip = audio_fadein.audio_fadein(audioclip, 0.15)
-            audioclip = audio_fadeout.audio_fadeout(audioclip, 0.15)
-            clip = clip.set_audio(audioclip)
         out_path = os.path.join(args.folder, "final_video.mp4")
         clip.write_videofile(out_path, fps=30, codec="libx264")
     else:
-        make_filmstrip(args.folder)
+        make_filmstrip(args.folder, audio_fit=args.audio_fit)
 
 
 if __name__ == "__main__":

--- a/ken_burns_reel/captions.py
+++ b/ken_burns_reel/captions.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from typing import Tuple, Optional
 import re
 
-from moviepy.editor import CompositeVideoClip, TextClip
+try:
+    from moviepy.editor import CompositeVideoClip, TextClip
+except ModuleNotFoundError:  # moviepy >=2.0
+    from moviepy import CompositeVideoClip, TextClip
 
 CAPTION_MAXLEN = 120
 CAPTION_MIN_ALNUM = 3

--- a/ken_burns_reel/config.py
+++ b/ken_burns_reel/config.py
@@ -5,13 +5,17 @@ import os
 from shutil import which
 
 import pytesseract
-from moviepy.config import change_settings
+try:
+    from moviepy.config import change_settings
+except ImportError:  # moviepy >=2.0
+    change_settings = None
 
 # Default binaries (can be overridden via environment)
 IMAGEMAGICK_BINARY = os.environ.get(
     "IMAGEMAGICK_BINARY"
 ) or r"C:\\Program Files\\ImageMagick-7.1.2-Q16-HDRI\\magick.exe"
-change_settings({"IMAGEMAGICK_BINARY": IMAGEMAGICK_BINARY})
+if change_settings:
+    change_settings({"IMAGEMAGICK_BINARY": IMAGEMAGICK_BINARY})
 
 pytesseract.pytesseract.tesseract_cmd = (
     os.environ.get("TESSERACT_BINARY")

--- a/ken_burns_reel/transitions.py
+++ b/ken_burns_reel/transitions.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from moviepy.editor import CompositeVideoClip
+try:
+    from moviepy.editor import CompositeVideoClip
+except ModuleNotFoundError:  # moviepy >=2.0
+    from moviepy import CompositeVideoClip
 
 
 def slide_transition(prev_clip, next_clip, duration: float, size: Tuple[int, int], fps: int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ken-burns-reel"
+version = "0.2.0"
+description = "Automatyczne generowanie wideo z obrazków (Ken Burns + komiksowe panele)"
+authors = [{ name="PKrokosz" }]
+dependencies = []
+
+[tool.setuptools.packages.find]
+include = ["ken_burns_reel*"]
+exclude = ["legacy_old*"]

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -1,5 +1,8 @@
 from ken_burns_reel.transitions import slide_transition
-from moviepy.editor import ColorClip
+try:
+    from moviepy.editor import ColorClip
+except ModuleNotFoundError:  # moviepy >=2.0
+    from moviepy import ColorClip
 
 
 def test_slide_transition_basic():


### PR DESCRIPTION
## Summary
- add audio-fit strategies and dwell-mode option to panel builder
- cache OCR per page and clamp CLAHE gamma
- document new flags and package metadata

## Testing
- `pip install -e .`
- `pip install -r requirements.txt`
- `pip install opencv-python-headless`
- `pip install 'moviepy<2' --force-reinstall`
- `pip install 'numpy<2.3' --force-reinstall`
- `ruff check .` *(fails: F401 remove unused import, etc.)*
- `mypy .` *(fails: Skipping analyzing "moviepy.editor"...)*
- `python -m ken_burns_reel . --dry-run` *(fails: unrecognized arguments: --dry-run)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896bcea29688321bb779faa77b8756a