### PR TITLE
fix(audio,easing): pad trim with silence to avoid EOF, monotonic ease-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ python -m ken_burns_reel <ścieżka_do_folderu_z_obrazkami> --output output.mp4
 
 **Najważniejsze opcje CLI**:
 - `--audio-fit {trim,silence,loop}` — dopasowanie długości audio do wideo
+- `--audio-fit trim` — jeśli audio jest krótsze niż wideo, narzędzie automatycznie dopełnia ciszą (z fade-in/out), żeby uniknąć błędów odtwarzacza.
 - `--dwell-mode {first,each}` — zatrzymanie tylko na pierwszym panelu lub na każdym
 - `--align-beat` — dociąga start stron do beatu (±0.08 s, bez ujemnych segmentów)
 - `--debug-panels` — zapisuje podgląd wykrytych paneli i kończy działanie


### PR DESCRIPTION
## Summary
- pad short audio in trim mode with generated silence to avoid EOF errors
- adjust travel easing to monotonic ease-in for smoother panel transitions
- document trim audio-fit behavior in README

## Testing
- `ruff check .` *(fails: F401 unused imports)*
- `mypy .` *(fails: Skipping analyzing, missing stubs and other typing issues)*
- `python -m ken_burns_reel . --dry-run` *(fails: ImportError: libGL.so.1: cannot open shared object file)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896c86750f083219adbb22cc47b3149