### PR TITLE
Add CLI range validation and export profile tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,53 @@ Projekt zawiera modularną architekturę z możliwością modyfikacji poszczegó
 
 ---
 
+## 🚀 Quick start
+
+**Bash**
+
+```bash
+python -m ken_burns_reel . --mode panels \
+  --bg-mode blur --page-scale 0.94 --bg-parallax 0.85 \
+  --profile social
+```
+
+**PowerShell** (multiline używa backticka \`)
+
+```powershell
+python -m ken_burns_reel . `
+  --mode panels `
+  --bg-mode blur `
+  --page-scale 0.94 `
+  --bg-parallax 0.85 `
+  --profile social
+```
+
+**CMD** (multiline używa znaku ^)
+
+```cmd
+python -m ken_burns_reel . --mode panels ^
+  --bg-mode blur ^
+  --page-scale 0.94 ^
+  --bg-parallax 0.85 ^
+  --profile social
+```
+
+Przykłady wymiarowania:
+
+```bash
+# 16:9 poziomo
+python -m ken_burns_reel . --mode panels --size 1920x1080 \
+  --bg-mode blur --page-scale 0.94 --profile social
+
+# 9:16 pionowo
+python -m ken_burns_reel . --mode panels --aspect 9:16 --height 1080 \
+  --bg-mode blur --page-scale 0.94 --profile social
+```
+
+Rekomendowana wartość `--page-scale` mieści się w zakresie `0.90–0.95`.
+
+---
+
 ## 📂 Struktura projektu
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ken-burns-reel"
-version = "0.2.0"
+version = "0.3.0"
 description = "Automatyczne generowanie wideo z obrazków (Ken Burns + komiksowe panele)"
 authors = [{ name="PKrokosz" }]
 dependencies = []


### PR DESCRIPTION
## Summary
- document cross-platform quick start usage and recommended page-scale
- validate panel animation CLI ranges and support legacy `--easing` flag
- tag HEVC exports with `hvc1` and enable faststart in ffmpeg profiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896e1b0b8f48321827b12cfeaf4054a