### PR TITLE
Add panel export, panel-first mode, and new transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ Rekomendowana wartość `--page-scale` mieści się w zakresie `0.90–0.95`.
 
 ---
 
+### Eksport paneli
+
+```bash
+python -m ken_burns_reel input_pages --export-panels panels --export-mode rect
+```
+
+### Tryb panel-first
+
+**PowerShell** (multiline backtick)
+
+```powershell
+python -m ken_burns_reel .\panels `
+  --mode panels-items `
+  --trans smear --trans-dur 0.32 --smear-strength 1.1 `
+  --bg-mode blur --page-scale 0.92 --bg-parallax 0.85 `
+  --profile preview
+```
+
+**Bash**
+
+```bash
+python -m ken_burns_reel panels --mode panels-items \
+  --size 1920x1080 --trans whip --trans-dur 0.28 \
+  --profile social
+```
+
+---
+
 ## 📂 Struktura projektu
 
 ```

--- a/ken_burns_reel/transitions.py
+++ b/ken_burns_reel/transitions.py
@@ -2,11 +2,15 @@
 from __future__ import annotations
 
 from typing import Tuple
+import math
+
+import numpy as np
+import cv2
 
 try:
-    from moviepy.editor import CompositeVideoClip
+    from moviepy.editor import CompositeVideoClip, VideoClip
 except ModuleNotFoundError:  # moviepy >=2.0
-    from moviepy import CompositeVideoClip
+    from moviepy import CompositeVideoClip, VideoClip
 
 
 def slide_transition(prev_clip, next_clip, duration: float, size: Tuple[int, int], fps: int):
@@ -28,3 +32,95 @@ def slide_transition(prev_clip, next_clip, duration: float, size: Tuple[int, int
         .set_duration(duration)
         .set_fps(fps)
     )
+
+
+def smear_transition(
+    prev_clip,
+    next_clip,
+    duration: float,
+    size: Tuple[int, int],
+    vec: Tuple[float, float],
+    steps: int = 12,
+    strength: float = 1.0,
+    fps: int = 30,
+):
+    """Directional smear (pseudo motion blur) between clips."""
+
+    W, H = size
+    tail = prev_clip.subclip(prev_clip.duration - duration, prev_clip.duration)
+    head = next_clip.subclip(0, duration)
+    dx, dy = vec
+
+    def make_frame(t):
+        p = t / duration
+        frame_prev = tail.get_frame(t).astype(np.uint8)
+        frame_next = head.get_frame(t).astype(np.uint8)
+        acc_prev = np.zeros_like(frame_prev, dtype=np.float32)
+        acc_next = np.zeros_like(frame_next, dtype=np.float32)
+        for i in range(steps):
+            s = i / max(1, steps - 1)
+            M1 = np.float32([[1, 0, -dx * p * s * strength], [0, 1, -dy * p * s * strength]])
+            warped1 = cv2.warpAffine(
+                frame_prev, M1, (W, H), borderMode=cv2.BORDER_REFLECT
+            )
+            acc_prev += warped1.astype(np.float32)
+            M2 = np.float32([[1, 0, (1 - p) * dx * (1 - s) * strength], [0, 1, (1 - p) * dy * (1 - s) * strength]])
+            warped2 = cv2.warpAffine(
+                frame_next, M2, (W, H), borderMode=cv2.BORDER_REFLECT
+            )
+            acc_next += warped2.astype(np.float32)
+        smear_prev = acc_prev / steps
+        smear_next = acc_next / steps
+        alpha = p
+        frame = (1 - alpha) * smear_prev + alpha * smear_next
+        return np.clip(frame, 0, 255).astype(np.uint8)
+
+    return VideoClip(make_frame=make_frame, duration=duration).set_fps(fps)
+
+
+def whip_pan_transition(
+    prev_clip,
+    next_clip,
+    duration: float,
+    size: Tuple[int, int],
+    vec: Tuple[float, float],
+    fps: int = 30,
+):
+    """Whip-pan style transition with eased velocity and brightness dip."""
+
+    W, H = size
+    tail = prev_clip.subclip(prev_clip.duration - duration, prev_clip.duration)
+    head = next_clip.subclip(0, duration)
+    dx, dy = vec
+
+    def ease(t: float) -> float:
+        a = t**3
+        b = (1 - t) ** 3
+        return a / (a + b) if a + b > 0 else t
+
+    def make_frame(t):
+        p = ease(t / duration)
+        frame_prev = tail.get_frame(t).astype(np.uint8)
+        frame_next = head.get_frame(t).astype(np.uint8)
+        shift_prev = (-dx * p, -dy * p)
+        shift_next = ((1 - p) * dx, (1 - p) * dy)
+        M1 = np.float32([[1, 0, shift_prev[0]], [0, 1, shift_prev[1]]])
+        M2 = np.float32([[1, 0, shift_next[0]], [0, 1, shift_next[1]]])
+        prev_w = cv2.warpAffine(
+            frame_prev, M1, (W, H), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT
+        )
+        next_w = cv2.warpAffine(
+            frame_next, M2, (W, H), flags=cv2.INTER_LINEAR, borderMode=cv2.BORDER_REFLECT
+        )
+        blur = int(1 + 6 * p * (1 - p))
+        if blur % 2 == 0:
+            blur += 1
+        prev_b = cv2.GaussianBlur(prev_w, (blur, blur), 0)
+        next_b = cv2.GaussianBlur(next_w, (blur, blur), 0)
+        alpha = p
+        frame = (1 - alpha) * prev_b + alpha * next_b
+        if 0.4 <= p <= 0.6:
+            frame *= 0.9
+        return np.clip(frame, 0, 255).astype(np.uint8)
+
+    return VideoClip(make_frame=make_frame, duration=duration).set_fps(fps)

--- a/tests/test_panels_items.py
+++ b/tests/test_panels_items.py
@@ -1,0 +1,73 @@
+import os
+import numpy as np
+from PIL import Image
+
+from ken_burns_reel.panels import export_panels
+from ken_burns_reel.transitions import smear_transition, whip_pan_transition
+from ken_burns_reel.builder import make_panels_items_sequence
+
+try:
+    from moviepy.editor import ColorClip
+except ModuleNotFoundError:  # moviepy >=2.0
+    from moviepy import ColorClip
+
+
+def _make_test_page(tmp_path):
+    arr = np.full((100, 200, 3), 255, dtype=np.uint8)
+    # two dark panels
+    import cv2
+
+    cv2.rectangle(arr, (10, 10), (90, 90), (0, 0, 0), -1)
+    cv2.rectangle(arr, (110, 10), (190, 90), (0, 0, 0), -1)
+    p = tmp_path / "page.png"
+    Image.fromarray(arr).save(p)
+    return p
+
+
+def test_export_panels_rect_and_mask(tmp_path):
+    page = _make_test_page(tmp_path)
+    out_rect = tmp_path / "rect"
+    paths = export_panels(str(page), str(out_rect), mode="rect")
+    assert len(paths) == 2
+    assert all(os.path.getsize(p) > 0 for p in paths)
+
+    out_mask = tmp_path / "mask"
+    paths_m = export_panels(str(page), str(out_mask), mode="mask")
+    assert len(paths_m) == 2
+    with Image.open(paths_m[0]) as im:
+        assert im.mode == "RGBA"
+        alpha = np.array(im)[:, :, 3]
+        assert np.any(alpha < 255)
+
+
+def test_smear_transition_basic():
+    clip1 = ColorClip(size=(100, 80), color=(255, 0, 0)).set_duration(1).set_fps(24)
+    clip2 = ColorClip(size=(100, 80), color=(0, 255, 0)).set_duration(1).set_fps(24)
+    trans = smear_transition(clip1, clip2, 0.2, (100, 80), vec=(20, 0))
+    f0 = trans.get_frame(0)
+    fmid = trans.get_frame(0.1)
+    fend = trans.get_frame(0.2 - 1e-6)
+    assert np.allclose(f0, clip1.get_frame(0.8), atol=1)
+    assert np.allclose(fend, clip2.get_frame(0), atol=1)
+    assert not np.allclose(fmid, f0)
+    assert not np.allclose(fmid, fend)
+
+
+def test_whip_pan_transition_basic():
+    clip1 = ColorClip(size=(100, 80), color=(0, 0, 255)).set_duration(1).set_fps(24)
+    clip2 = ColorClip(size=(100, 80), color=(0, 255, 0)).set_duration(1).set_fps(24)
+    trans = whip_pan_transition(clip1, clip2, 0.2, (100, 80), vec=(20, 0))
+    f0 = trans.get_frame(0)
+    fend = trans.get_frame(0.2 - 1e-6)
+    assert np.allclose(f0, clip1.get_frame(0.8), atol=1)
+    assert np.allclose(fend, clip2.get_frame(0), atol=1)
+
+
+def test_make_panels_items_sequence_duration(tmp_path):
+    p1 = tmp_path / "p1.png"
+    p2 = tmp_path / "p2.png"
+    Image.new("RGB", (50, 50), (10, 20, 30)).save(p1)
+    Image.new("RGB", (50, 50), (30, 20, 10)).save(p2)
+    clip = make_panels_items_sequence([str(p1), str(p2)], dwell=0.5, trans="smear", trans_dur=0.3)
+    assert abs(clip.duration - (0.5 * 2 + 0.3)) < 0.05
+    assert clip.size == [1080, 1920] or clip.size == (1080, 1920)


### PR DESCRIPTION
## Summary
- add `export_panels` API for saving panel crops or masks
- implement `smear_transition` and `whip_pan_transition`
- introduce `make_panels_items_sequence` builder and CLI support for panel-first mode
- document panel export, panel-first workflow, and transition options

## Testing
- `pytest -q`
- `ruff check . || true`
- `mypy . || true`


------
https://chatgpt.com/codex/tasks/task_e_6896e3e04fb48321a239fd3bf8402ac0