### PR TITLE
feat: add blur and glow to overlay with roughened masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ oraz winietę, dzięki czemu tło jest stonowane.
 - `stretch`
 - `gradient`
 
+#### Overlay z trzema warstwami
+
+Tryb `panels-overlay` może korzystać z rozmytego, prawie statycznego tła i
+lewitujących paneli. Przydatne flagi:
+
+- `--bg-blur` – poziom rozmycia tła (domyślnie 8.0)
+- `--bg-parallax` – siła ruchu tła (domyślnie 0.05 w `panels-overlay`)
+- `--roughen`, `--roughen-scale` – nieregularne krawędzie masek paneli
+- `--export-mode rect` – zapis prostokątnych paneli z pełną alfą
+
 ---
 
 ## 📂 Struktura projektu

--- a/tests/test_mask_processing.py
+++ b/tests/test_mask_processing.py
@@ -1,0 +1,34 @@
+import numpy as np
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+from ken_burns_reel.panels import export_panels
+
+
+def _make_page_with_hole(path: Path) -> None:
+    img = Image.new("RGB", (200, 200), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([20, 20, 180, 180], fill=(128, 128, 128))
+    draw.rectangle([40, 40, 160, 160], fill="white")
+    img.save(path)
+
+
+def test_rect_fallback(tmp_path: Path) -> None:
+    page = tmp_path / "page.png"
+    _make_page_with_hole(page)
+    out_dir = tmp_path / "panels" / "page_0001"
+    out_dir.mkdir(parents=True)
+    export_panels(
+        str(page),
+        str(out_dir),
+        mode="mask",
+        bleed=0,
+        tight_border=0,
+        feather=0,
+        mask_fill_holes=0,
+        mask_close=0,
+        mask_rect_fallback=0.1,
+    )
+    panel_path = next(out_dir.glob("panel_*.png"))
+    alpha = np.array(Image.open(panel_path).convert("RGBA"))[..., 3]
+    assert alpha.min() == 255  # fallback to rect crop

--- a/tests/test_masks_fillholes.py
+++ b/tests/test_masks_fillholes.py
@@ -1,0 +1,35 @@
+import numpy as np
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+from ken_burns_reel.panels import export_panels
+
+
+def _make_page_face_bubble(path: Path) -> None:
+    img = Image.new("RGB", (200, 200), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([20, 20, 180, 180], fill=(128, 128, 128))
+    draw.ellipse([40, 40, 80, 80], fill="white")  # speech bubble
+    draw.ellipse([110, 80, 150, 120], fill="white")  # face
+    img.save(path)
+
+
+def test_mask_fill_holes_speech_and_skin(tmp_path: Path) -> None:
+    page = tmp_path / "page.png"
+    _make_page_face_bubble(page)
+    out_dir = tmp_path / "panels" / "page_0001"
+    out_dir.mkdir(parents=True)
+    export_panels(
+        str(page),
+        str(out_dir),
+        mode="mask",
+        bleed=0,
+        tight_border=0,
+        feather=0,
+        roughen=0.0,
+        mask_rect_fallback=1.0,
+    )
+    panel_path = next(out_dir.glob("panel_*.png"))
+    alpha = np.array(Image.open(panel_path).convert("RGBA"))[..., 3]
+    assert alpha[60, 60] >= 250  # bubble interior
+    assert alpha[100, 100] >= 250  # face interior

--- a/tests/test_overlay_aspect.py
+++ b/tests/test_overlay_aspect.py
@@ -1,0 +1,14 @@
+from ken_burns_reel.builder import _fit_window_to_box
+
+
+def test_overlay_keeps_aspect() -> None:
+    img_w = img_h = 200
+    box = (20, 20, 100, 150)
+    cx, cy, win_w, win_h = _fit_window_to_box(img_w, img_h, box, (200, 200))
+    x, y, w, h = box
+    S = 200 / win_w
+    dst_w = int(round(w * S * 1.6))
+    dst_h = int(round(h * S * 1.6))
+    ar_final = dst_w / dst_h
+    ar_orig = w / h
+    assert abs(ar_final - ar_orig) / ar_orig <= 0.005

--- a/tests/test_overlay_bg.py
+++ b/tests/test_overlay_bg.py
@@ -1,0 +1,61 @@
+import numpy as np
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+from ken_burns_reel.builder import make_panels_overlay_sequence
+from ken_burns_reel.panels import export_panels, detect_panels, order_panels_lr_tb
+
+
+def _make_two_panel_page(path: Path) -> None:
+    img = Image.new("RGB", (200, 100), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([10, 10, 90, 90], fill=(50, 50, 50))
+    draw.rectangle([110, 10, 190, 90], fill=(80, 80, 80))
+    img.save(path)
+
+
+def test_bg_is_stable_vs_fg_motion(tmp_path: Path) -> None:
+    page_path = tmp_path / "page.png"
+    _make_two_panel_page(page_path)
+    panels_dir = tmp_path / "panels" / "page_0001"
+    panels_dir.mkdir(parents=True)
+    export_panels(
+        str(page_path),
+        str(panels_dir),
+        mode="rect",
+        bleed=0,
+        tight_border=0,
+        feather=0,
+        roughen=0.0,
+    )
+    clip = make_panels_overlay_sequence(
+        [str(page_path)],
+        str(tmp_path / "panels"),
+        target_size=(200, 100),
+        fps=10,
+        dwell=0.2,
+        travel=0.0,
+        trans_dur=0.0,
+        parallax_bg=0.05,
+        parallax_fg=0.0,
+        bg_blur=0.0,
+    )
+    frame1 = clip.get_frame(0.1)
+    frame2 = clip.get_frame(0.25)
+    lum1 = frame1.mean(axis=2)
+    lum2 = frame2.mean(axis=2)
+    diff = np.abs(lum1 - lum2)
+    with Image.open(page_path) as im:
+        boxes = order_panels_lr_tb(detect_panels(im))
+        scale_x = 200 / im.width
+        scale_y = 100 / im.height
+    fg_mask = np.zeros(diff.shape, dtype=bool)
+    for x, y, w, h in boxes:
+        xs = int(round(x * scale_x))
+        ys = int(round(y * scale_y))
+        xe = int(round((x + w) * scale_x))
+        ye = int(round((y + h) * scale_y))
+        fg_mask[ys:ye, xs:xe] = True
+    fg_delta = diff[fg_mask].mean()
+    bg_delta = diff[~fg_mask].mean()
+    assert bg_delta < 0.25 * fg_delta


### PR DESCRIPTION
## Summary
- expose background blur, texture, glow and roughen controls in CLI with safer panels-overlay defaults
- seal and roughen panel masks with fill-holes and rectangular alpha fallback
- blur and stabilize overlay backgrounds while adding optional foreground glow

## Testing
- `ruff check . || true`
- `mypy . || true`
- `python -m ken_burns_reel . --dry-run || true`
- `PYTHONPATH=. pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68976cb5219883218194680bb0ed609e