### PR TITLE
Add overlay parameter fallbacks for one-click mode

### DIFF
--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -103,6 +103,9 @@ def _run_oneclick(args: argparse.Namespace, target_size: tuple[int, int]) -> Non
         elif args.align_beat and not audio_path:
             print("⚠️ Nie znaleziono pliku audio – wideo bez wyrównania do beatów.")
             args.align_beat = False
+        overlay_scale = args.overlay_scale if args.overlay_scale is not None else 1.6
+        overlay_fit = args.overlay_fit if args.overlay_fit is not None else 0.7
+        overlay_mode = args.overlay_mode or "anchored"
 
         clip = make_panels_overlay_sequence(
             page_paths,
@@ -114,9 +117,9 @@ def _run_oneclick(args: argparse.Namespace, target_size: tuple[int, int]) -> Non
             travel_ease="inout",
             align_beat=args.align_beat,
             beat_times=beat_times,
-            overlay_fit=args.overlay_fit,
-            overlay_mode=args.overlay_mode,
-            overlay_scale=args.overlay_scale,
+            overlay_fit=overlay_fit,
+            overlay_mode=overlay_mode,
+            overlay_scale=overlay_scale,
             bg_source="page",
             bg_blur=args.bg_blur,
             bg_tex=args.bg_tex,


### PR DESCRIPTION
## Summary
- ensure one-click workflow uses sensible defaults for overlay scale, fit, and mode

## Testing
- `ruff check .` (fails: F401 unused imports and E741 ambiguous variable names)
- `mypy .` (errors: missing type stubs for moviepy/pytesseract)
- `pytest -q` (22 failed, 7 passed, 11 skipped)
- `python -m ken_burns_reel . --dry-run` (error: unrecognized arguments: --dry-run)

------
https://chatgpt.com/codex/tasks/task_e_6899f673f8608321acf6d9f594562d30