### PR TITLE
refactor: simplify binary resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ lewitujących paneli. Przydatne flagi:
 
 ```
 ken_burns_scroll_audio.py      # Skrypt CLI do generowania wideo ze skrolowaniem i audio
-moviepy_config_defaults.py     # Domyślne ustawienia MoviePy
 ken_burns_reel/
  ├── __main__.py                # Główny punkt wejścia pakietu
  ├── __init__.py
@@ -189,7 +188,7 @@ pip install -e .
 
 1. Parametry CLI `--magick` / `--tesseract`.
 2. Zmienne środowiskowe `IMAGEMAGICK_BINARY` / `TESSERACT_BINARY`.
-3. Ustawienia bibliotek (MoviePy, pytesseract).
+3. Dla Tesseract: `pytesseract.pytesseract.tesseract_cmd`.
 4. Wyszukanie w `PATH` systemowym.
 
 Jeśli narzędzie nie zostanie znalezione, napisy/OCR mogą zostać pominięte.

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -11,7 +11,7 @@
   Wywołuje `extract_beats`, `extract_caption`, `detect_focus_point`, `overlay_caption`.
 
 ### `ken_burns_reel/config.py`
-- Konfiguracja środowiska (`IMAGEMAGICK_BINARY`, `tesseract_cmd`). Definiuje rozszerzenia `IMAGE_EXTS`, `AUDIO_EXTS`.
+- Definiuje rozszerzenia `IMAGE_EXTS`, `AUDIO_EXTS`.
 
 ### `ken_burns_reel/focus.py`
 - `detect_focus_point(img: Image.Image) -> Tuple[int, int]` – detekcja twarzy (`opencv`) lub centroid jasności (`numpy`).

--- a/ken_burns_reel/bin_config.py
+++ b/ken_burns_reel/bin_config.py
@@ -1,9 +1,8 @@
 """Helpers to resolve external binary paths.
 
 This module centralizes discovery of ImageMagick and Tesseract executables
-without requiring hard coded paths. Resolution order follows CLI arguments,
-environment variables, existing library configuration and finally a search on
-``PATH``.
+without requiring hard coded paths. ImageMagick detection honors an explicit
+CLI argument, environment variables and finally a search on ``PATH``.
 """
 from __future__ import annotations
 
@@ -11,7 +10,6 @@ import os
 import shutil
 from typing import Optional
 
-import moviepy.config as mpyconf
 import pytesseract
 
 
@@ -30,25 +28,19 @@ def resolve_imagemagick(cli_path: str | None = None) -> Optional[str]:
     Resolution order:
     1. explicit ``cli_path`` argument (e.g. ``--magick``)
     2. ``IMAGEMAGICK_BINARY`` environment variable
-    3. MoviePy configuration
-    4. ``magick`` discovered on ``PATH``
-    The returned path is validated and applied to MoviePy configuration and
-    ``os.environ``. Returns ``None`` if no candidate is found.
+    3. ``magick`` discovered on ``PATH``
+    The returned path is validated and stored in ``os.environ``. Returns
+    ``None`` if no candidate is found.
     """
     candidates = [
         cli_path,
         os.environ.get("IMAGEMAGICK_BINARY"),
-        getattr(mpyconf, "IMAGEMAGICK_BINARY", None),
         shutil.which("magick"),
     ]
     for cand in candidates:
         path = _validate_binary(cand)
         if path:
             os.environ["IMAGEMAGICK_BINARY"] = path
-            try:
-                mpyconf.change_settings({"IMAGEMAGICK_BINARY": path})
-            except Exception:
-                pass
             return path
     return None
 

--- a/ken_burns_reel/config.py
+++ b/ken_burns_reel/config.py
@@ -1,27 +1,5 @@
-"""Configuration helpers for ken_burns_reel."""
+"""Static configuration for ken_burns_reel."""
 from __future__ import annotations
-
-import os
-from shutil import which
-
-import pytesseract
-try:
-    from moviepy.config import change_settings
-except ImportError:  # moviepy >=2.0
-    change_settings = None
-
-# Default binaries (can be overridden via environment)
-IMAGEMAGICK_BINARY = os.environ.get(
-    "IMAGEMAGICK_BINARY"
-) or r"C:\\Program Files\\ImageMagick-7.1.2-Q16-HDRI\\magick.exe"
-if change_settings:
-    change_settings({"IMAGEMAGICK_BINARY": IMAGEMAGICK_BINARY})
-
-pytesseract.pytesseract.tesseract_cmd = (
-    os.environ.get("TESSERACT_BINARY")
-    or which("tesseract")
-    or pytesseract.pytesseract.tesseract_cmd
-)
 
 IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
 AUDIO_EXTS = {".mp3", ".wav", ".m4a"}

--- a/moviepy_config_defaults.py
+++ b/moviepy_config_defaults.py
@@ -1,1 +1,0 @@
-IMAGEMAGICK_BINARY = "C:\\Program Files\\ImageMagick-7.1.2-Q16-HDRI\\magick.exe"


### PR DESCRIPTION
## Summary
- drop `moviepy_config_defaults.py`
- resolve ImageMagick from CLI/env/PATH only
- trim leftover config and docs

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: AttributeError: 'ImageClip' object has no attribute 'set_duration' ...)*
- `ruff check .` *(fails: F401, E741...)*
- `mypy .` *(fails: Skipping analyzing "moviepy.editor" ...)*
- `python -m ken_burns_reel . --dry-run` *(fails: error: unrecognized arguments: --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_6899f6a40c288321bf6108c5a3b28545