### PR TITLE
Expand .gitignore for Python build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,16 @@
-__pycache__/
+**/__pycache__/
 *.pyc
 *.pyo
 *.pyd
+build/
+dist/
+*.egg-info
 *.mp4
 *.wav
 *.mp3
+*.log
 .env
 .DS_Store
 .pytest_cache/
 .venv/
+.coverage


### PR DESCRIPTION
## Summary
- ignore common Python build and coverage artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'soundfile')*
- `ruff check .` *(fails: F401, E741, F841 and others)*
- `mypy .` *(fails: Found 85 errors in 16 files)*
- `python -m ken_burns_reel . --dry-run` *(fails: ModuleNotFoundError: No module named 'pytesseract')*

------
https://chatgpt.com/codex/tasks/task_e_6899f6b508b083219b0f96fc2653b31e