### PR TITLE
chore: move ken_burns_scroll_audio example to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ lewitujących paneli. Przydatne flagi:
 ## 📂 Struktura projektu
 
 ```
-ken_burns_scroll_audio.py      # Skrypt CLI do generowania wideo ze skrolowaniem i audio
+scripts/ken_burns_scroll_audio.py      # Przykładowy skrypt CLI do generowania wideo ze skrolowaniem i audio
 ken_burns_reel/
  ├── __main__.py                # Główny punkt wejścia pakietu
  ├── __init__.py

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -30,6 +30,9 @@
 ### `ken_burns_reel/__main__.py`
 - `main()` – CLI; sprawdza tesseract i uruchamia `make_filmstrip`.
 
+### `scripts/ken_burns_scroll_audio.py`
+- Przykładowy skrypt CLI do generowania wideo ze skrolowaniem i audio.
+
 ## Grupy funkcjonalne
 - **OCR/Caption**: `extract_caption`, `overlay_caption`, `verify_tesseract_available`.
 - **Focus/Compose**: `detect_focus_point`, `smart_crop`, `ken_burns_scroll`.

--- a/scripts/ken_burns_scroll_audio.py
+++ b/scripts/ken_burns_scroll_audio.py
@@ -13,7 +13,6 @@ from moviepy.editor import (
     ImageClip,
     concatenate_videoclips,
 )
-from moviepy.video.fx.all import crop
 
 from ken_burns_reel.bin_config import resolve_imagemagick, resolve_tesseract
 from ken_burns_reel.captions import overlay_caption


### PR DESCRIPTION
## Summary
- move ken_burns_scroll_audio example into new scripts directory
- update README and AUDIT docs to reference new script location
- drop unused import in example script

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: AudioFadeOut.__init__ takes 2 positional args but 3 given, etc.)*
- `ruff check scripts/ken_burns_scroll_audio.py`
- `mypy .` *(module is installed, but missing library stubs or py.typed marker)*
- `python -m ken_burns_reel . --dry-run` *(unrecognized arguments: --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_6899fb6719f88321915b28d438a0ff7c