### PR TITLE
feat: add preset loading and transition flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,36 @@ python -m ken_burns_reel . --mode panels \
   --profile social
 ```
 
+Presety można wczytać przez `--preset <plik.yaml>`; repo zawiera m.in.
+`styles/float_black_v1.yaml`. Hierarchia: domyślne < style preset < motion preset <
+flagi CLI.
+
+### 2-page test
+
+**Bash**
+
+```bash
+python -m ken_burns_reel two_pages \
+  --preset styles/float_black_v1.yaml \
+  --transition-duration 0.3
+```
+
+**PowerShell**
+
+```powershell
+python -m ken_burns_reel two_pages `
+  --preset styles/float_black_v1.yaml `
+  --transition-duration 0.3
+```
+
+**CMD**
+
+```cmd
+python -m ken_burns_reel two_pages ^
+  --preset styles\float_black_v1.yaml ^
+  --transition-duration 0.3
+```
+
 Szczegółowe przykłady CLI znajdują się w [docs/cli_examples.md](docs/cli_examples.md).
 
 ## Tests

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -58,7 +58,7 @@ python -m ken_burns_reel input_pages --export-panels panels --export-mode rect
 ```powershell
 python -m ken_burns_reel .\panels `
   --mode panels-items `
-  --trans smear --trans-dur 0.32 --smear-strength 1.1 `
+  --trans smear --transition-duration 0.32 --smear-strength 1.1 `
   --bg-mode blur --page-scale 0.92 --bg-parallax 0.85 `
   --profile preview
 ```
@@ -67,7 +67,7 @@ python -m ken_burns_reel .\panels `
 
 ```bash
 python -m ken_burns_reel panels --mode panels-items \
-  --size 1920x1080 --trans whip --trans-dur 0.28 \
+  --size 1920x1080 --trans whip --transition-duration 0.28 \
   --profile social
 ```
 

--- a/ken_burns_reel/builder.py
+++ b/ken_burns_reel/builder.py
@@ -599,7 +599,7 @@ def make_panels_cam_sequence(
     fps: int = 30,
     dwell: float = 1.0,
     travel: float = 0.6,
-    xfade: float = 0.4,
+    trans_dur: float = 0.4,
     settle: float = 0.14,
     travel_ease: str = "inout",
     dwell_scale: float = 1.0,
@@ -647,7 +647,7 @@ def make_panels_cam_sequence(
     # prepare start times
     starts = [0.0]
     for i in range(1, len(clips)):
-        start = starts[i - 1] + clips[i - 1].duration - xfade
+        start = starts[i - 1] + clips[i - 1].duration - trans_dur
         if align_beat and beat_times:
             nearest = min(beat_times, key=lambda b: abs(b - start))
             delta = nearest - start
@@ -660,7 +660,7 @@ def make_panels_cam_sequence(
     for i, clip in enumerate(clips):
         clip = clip.set_start(starts[i])
         if i > 0:
-            clip = clip.crossfadein(xfade)
+            clip = clip.crossfadein(trans_dur)
         clips[i] = clip
 
     # audio fades for crossfade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ken-burns-reel"
-version = "0.3.0"
+version = "0.2.1+filmic"
 description = "Automatyczne generowanie wideo z obrazków (Ken Burns + komiksowe panele)"
 authors = [{ name="PKrokosz" }]
 dependencies = []
@@ -17,7 +17,8 @@ exclude = ["legacy_old*"]
 dev = [
   "pytest",
   "opencv-python-headless>=4.9",
-  "moviepy",
+  "moviepy<2",
   "numpy",
-  "Pillow"
+  "Pillow",
+  "PyYAML"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-moviepy
+moviepy<2
 numpy
 pytesseract
 librosa
@@ -6,3 +6,4 @@ opencv-python
 Pillow
 soundfile
 pytest
+pyyaml

--- a/styles/float_black_v1.yaml
+++ b/styles/float_black_v1.yaml
@@ -1,0 +1,10 @@
+bg_source: page
+bg_blur: 40
+bg_tex: none
+bg_tone_strength: 0.0
+parallax_bg: 0.85
+parallax_fg: 0.08
+fg_shadow: 0.22
+fg_shadow_blur: 14
+fg_shadow_offset: 4
+fg_shadow_mode: soft

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+from ken_burns_reel.__main__ import parse_args
+
+
+def test_preset_overrides_flags(tmp_path):
+    preset = tmp_path / "preset.yaml"
+    preset.write_text("dwell: 2.5\n")
+
+    args = parse_args([str(tmp_path), "--preset", str(preset)])
+    assert args.dwell == 2.5
+
+    args_cli = parse_args(
+        [str(tmp_path), "--preset", str(preset), "--dwell", "1.5"]
+    )
+    assert args_cli.dwell == 1.5

--- a/tests/video/test_sequence.py
+++ b/tests/video/test_sequence.py
@@ -19,7 +19,7 @@ def test_align_beat_snaps_start(tmp_path):
         [str(img1), str(img2)],
         target_size=(64, 64),
         fps=30,
-        xfade=0.0,
+        trans_dur=0.0,
         align_beat=True,
         beat_times=beats,
     )
@@ -27,7 +27,7 @@ def test_align_beat_snaps_start(tmp_path):
         [str(img1), str(img2)],
         target_size=(64, 64),
         fps=30,
-        xfade=0.0,
+        trans_dur=0.0,
         align_beat=False,
     )
     start_aligned = clip.clips[1].start


### PR DESCRIPTION
## Summary
- support YAML presets with style/motion hierarchy
- replace --xfade with --transition-duration (alias kept)
- add float_black_v1 style preset

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: test_bg_is_stable_vs_fg_motion, test_export_panels_rect_and_mask, test_overlay_anchored_projection, test_export_panels_gutter_thicken, test_overlay_center_and_fit, test_overlay_travel_ease, test_overlay_enhance_applied, test_overlay_clip_no_broadcast, test_no_broadcast_overlay_clip)*
- `ruff check .` *(fails: F401, E741, F841)*
- `mypy .` *(fails: many missing stubs and type errors)*
- `python -m ken_burns_reel . --dry-run` *(fails: unrecognized arguments: --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_689a647f683083219a2ee491c4b4c6bc