### PR TITLE
fix: consolidate float_black preset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Skrypt w Pythonie do automatycznego tworzenia wideo z serii obrazków, wykorzyst
 - Efekty warstwowe takie jak `page_shadow` oraz przejście `overlay_lift` z
   animowaną podmianą panelu.
 - Możliwość ładowania presetów stylu z plików YAML (np. `styles/float_black_v1.yaml`).
+  Wszystkie style znajdują się teraz w katalogu `styles/`.
 
 ## Kolor
 Ścieżka przetwarzania zachowuje stałą konwersję sRGB → linear → sRGB przy

--- a/ken_burns_reel/styles/float_black_v1.yaml
+++ b/ken_burns_reel/styles/float_black_v1.yaml
@@ -1,7 +1,0 @@
-page_shadow:
-  strength: 0.25
-  blur: 12
-  offset_xy: [6, 6]
-bottom_glow: 0.1
-frame: 0.05
-vignette: 0.4

--- a/styles/float_black_v1.yaml
+++ b/styles/float_black_v1.yaml
@@ -8,3 +8,10 @@ fg_shadow: 0.22
 fg_shadow_blur: 14
 fg_shadow_offset: 4
 fg_shadow_mode: soft
+page_shadow:
+  strength: 0.25
+  blur: 12
+  offset_xy: [6, 6]
+deep_bottom_glow: 0.1
+overlay_frame_px: 5
+bg_vignette: 0.4

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -2,19 +2,19 @@ import numpy as np
 
 try:
     from moviepy import ColorClip, CompositeVideoClip
-except ModuleNotFoundError:  # pragma: no cover
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
     from moviepy.editor import ColorClip, CompositeVideoClip
 
 from ken_burns_reel.transitions import fg_fade, _get_ease_fn
 
 
 def test_fg_fade_keeps_background():
-    bg = ColorClip(size=(4, 4), color=(0, 0, 0)).with_duration(1).with_fps(1)
+    bg = ColorClip(size=(4, 4), color=(0, 0, 0)).set_duration(1).set_fps(1)
     fg = (
         ColorClip(size=(4, 4), color=(255, 0, 0))
-        .with_duration(1)
-        .with_fps(1)
-        .with_opacity(1)
+        .set_duration(1)
+        .set_fps(1)
+        .set_opacity(1)
     )
     faded = fg_fade(fg, 1)
     comp = CompositeVideoClip([bg, faded])


### PR DESCRIPTION
## Summary
- merge float_black style preset into `styles/` with page shadow, bottom glow, frame and vignette settings
- document styles directory in README and remove duplicate preset
- stabilize MoviePy imports in tests

## Testing
- `pytest -q` *(fails: assert bg_delta < 0.25 * fg_delta, etc.)*
- `ruff check .` *(fails: F401 unused import, E741 ambiguous variable name, etc.)*
- `mypy .` *(fails: Skipping analyzing `moviepy.editor`, ... 87 errors)*
- `python -m ken_burns_reel . --dry-run` *(fails: unrecognized arguments: --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_689a6dfa33708321ab66b911359bf92a