### PR TITLE
fix(cli): promote transition-duration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ histogramy kanałów.
    Na Windows upewnij się, że katalog ImageMagick zawiera `colors.xml`, a `tesseract.exe` znajduje się w `PATH`.
 
 ## Usage
+
+### Renderowanie
 ```bash
 python -m ken_burns_reel . --mode panels \
   --bg-mode blur --page-scale 0.94 --bg-parallax 0.85 \
@@ -82,7 +84,9 @@ python -m ken_burns_reel two_pages ^
 
 Szczegółowe przykłady CLI znajdują się w [docs/cli_examples.md](docs/cli_examples.md).
 
-One-liner (PowerShell/Bash/CMD):
+### Walidacja / utility CLI
+Helper do walidacji i eksperymentów jest wystawiony jako
+`ken_burns_reel.cli`:
 
 ```
 python -m ken_burns_reel.cli --trans fg-fade --transition-duration 0.3 input_folder

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -239,12 +239,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--travel", type=float, default=0.6, help="Czas przejazdu między panelami (s)")
     parser.add_argument(
         "--transition-duration",
-        "--trans-dur",
-        "--xfade",
         dest="trans_dur",
         type=float,
         default=0.3,
         help="Długość przejścia/crossfadu między panelami (s)",
+    )
+    parser.add_argument(
+        "--trans-dur",
+        dest="trans_dur",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--xfade",
+        dest="trans_dur",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--settle", type=float, default=0.14, help="Długość micro-holdu (s)")
     parser.add_argument(

--- a/ken_burns_reel/cli.py
+++ b/ken_burns_reel/cli.py
@@ -13,12 +13,18 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Ken Burns Reel helper CLI")
     parser.add_argument("--trans", default="none", help="Transition type")
     parser.add_argument(
-        "--trans-dur",
         "--transition-duration",
         dest="trans_dur",
         type=float,
         default=0.0,
         help="Transition duration in seconds",
+    )
+    parser.add_argument(
+        "--trans-dur",
+        dest="trans_dur",
+        type=float,
+        default=argparse.SUPPRESS,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--fg-only", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument(
@@ -41,7 +47,7 @@ def build_parser() -> argparse.ArgumentParser:
 def validate_args(args: argparse.Namespace) -> list[str]:
     errors: list[str] = []
     if args.trans_dur < 0:
-        errors.append("--trans-dur must be >= 0")
+        errors.append("--transition-duration must be >= 0")
     if args.bg_offset and args.fg_offset:
         errors.append("conflict: --bg-offset with --fg-offset")
     if args.min_read < 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,12 @@ def test_preset_overrides_flags(tmp_path):
 
 def test_validate_blocks_negative_times(capsys):
     with pytest.raises(SystemExit):
-        cli.main(["--validate", "--trans-dur", "-1"])
+        cli.main(["--validate", "--transition-duration", "-1"])
     err = capsys.readouterr().err
-    assert "--trans-dur" in err
+    assert "--transition-duration" in err
+
+
+def test_trans_dur_alias_still_works(tmp_path):
+    args = parse_args([str(tmp_path), "--trans-dur", "0.5"])
+    assert args.trans_dur == 0.5
 

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -2,7 +2,7 @@ import numpy as np
 
 try:
     from moviepy import ColorClip, CompositeVideoClip
-except ModuleNotFoundError:  # pragma: no cover
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
     from moviepy.editor import ColorClip, CompositeVideoClip
 
 from ken_burns_reel.transitions import fg_fade, _get_ease_fn


### PR DESCRIPTION
## Summary
- make `--transition-duration` the canonical flag and hide `--trans-dur` alias
- clarify README usage between main renderer and helper CLI
- adjust tests for new flag behaviour

## Testing
- `ruff check . || true`
- `mypy . || true`
- `pytest -q` *(fails: test_bg_is_stable_vs_fg_motion, test_export_panels_rect_and_mask, test_overlay_anchored_projection, test_export_panels_gutter_thicken)*
- `python -m ken_burns_reel . --dry-run || true` *(error: unrecognized arguments: --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e0a96bc8321ba674653d99050af