### PR TITLE
refactor: unify arc path and deterministic drift

### DIFF
--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -80,14 +80,12 @@ python -m ken_burns_reel . --mode panels-overlay \
   --travel-ease inout
 ```
 
-## Overlay z ramką i driftem
+## Overlay z ramką
 
 ```bash
 python -m ken_burns_reel . --mode panels-overlay \
   --overlay-frame-px 8 --overlay-frame-color "#000000" \
   --bg-offset 0.0 --fg-offset 0.18 \
-  --bg-drift-zoom 0.008 --bg-drift-speed 0.06 \
-  --fg-drift-zoom 0.012 --fg-drift-speed 0.10 \
   --travel-path arc --deep-bottom-glow 0.30
 ```
 

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -157,10 +157,6 @@ def _run_oneclick(args: argparse.Namespace, target_size: tuple[int, int]) -> Non
             bg_offset=args.bg_offset,
             fg_offset=args.fg_offset,
             seed=args.seed,
-            bg_drift_zoom=args.bg_drift_zoom,
-            bg_drift_speed=args.bg_drift_speed,
-            fg_drift_zoom=args.fg_drift_zoom,
-            fg_drift_speed=args.fg_drift_speed,
             travel_path=args.travel_path,
             deep_bottom_glow=args.deep_bottom_glow,
             look=args.look,
@@ -476,10 +472,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--bg-offset", type=float, default=0.0, help="Opóźnienie ruchu tła (s)")
     parser.add_argument("--fg-offset", type=float, default=0.0, help="Opóźnienie ruchu panelu (s)")
     parser.add_argument("--seed", type=int, default=0, help="Seed deterministycznego driftu")
-    parser.add_argument("--bg-drift-zoom", type=float, default=0.0, help="Amplituda mikro-zoomu tła")
-    parser.add_argument("--bg-drift-speed", type=float, default=0.0, help="Częstotliwość mikro-zoomu tła (Hz)")
-    parser.add_argument("--fg-drift-zoom", type=float, default=0.0, help="Amplituda mikro-zoomu panelu")
-    parser.add_argument("--fg-drift-speed", type=float, default=0.0, help="Częstotliwość mikro-zoomu panelu (Hz)")
     parser.add_argument("--travel-path", choices=["linear", "arc"], default="linear", help="Tor przejazdu kamery")
     parser.add_argument("--deep-bottom-glow", type=float, default=0.0, help="Poświata od dołu (0..1)")
     parser.add_argument("--page-scale-overlay", type=_page_scale_type, default=1.0, help="Skala strony przy overlay")
@@ -769,10 +761,6 @@ def main(argv: list[str] | None = None) -> None:
             overlay_frame_color=args.overlay_frame_color,
             bg_offset=args.bg_offset,
             fg_offset=args.fg_offset,
-            bg_drift_zoom=args.bg_drift_zoom,
-            bg_drift_speed=args.bg_drift_speed,
-            fg_drift_zoom=args.fg_drift_zoom,
-            fg_drift_speed=args.fg_drift_speed,
             travel_path=args.travel_path,
             deep_bottom_glow=args.deep_bottom_glow,
             look=args.look,

--- a/ken_burns_reel/builder.py
+++ b/ken_burns_reel/builder.py
@@ -841,10 +841,6 @@ def make_panels_overlay_sequence(
     bg_offset: float = 0.0,
     fg_offset: float = 0.0,
     seed: int = 0,
-    bg_drift_zoom: float = 0.0,
-    bg_drift_speed: float = 0.0,
-    fg_drift_zoom: float = 0.0,
-    fg_drift_speed: float = 0.0,
     travel_path: str = "linear",
     deep_bottom_glow: float = 0.0,
     look: str = "none",
@@ -1106,10 +1102,6 @@ def make_panels_overlay_sequence(
                 frame = cv2.addWeighted(deep, 0.25, frame, 0.75, 0)
             if look == "witcher1":
                 frame = _apply_witcher_look(frame, bg_vignette)
-            if bg_drift_zoom > 0 and bg_drift_speed > 0:
-                phase = 2 * math.pi * bg_drift_speed * seg_start
-                scale = 1.0 + bg_drift_zoom * math.sin(phase + 2 * math.pi * bg_drift_speed * t)
-                frame = _zoom_image_center(frame, scale)
             if deep_bottom_glow > 0:
                 grad = np.linspace(1.0, 1.0 + deep_bottom_glow, Hout, dtype=np.float32)[:, None]
                 frame = np.clip(frame.astype(np.float32) * grad[..., None], 0, 255).astype(np.uint8)
@@ -1334,17 +1326,13 @@ def make_panels_overlay_sequence(
                 if tt > dwell:
                     p = (tt - dwell) / max(1e-6, travel)
                     p = ease_fn(p)
-                    offx = (cx1 - cx0) * parallax_fg * p * scale_x
-                    offy = (cy1 - cy0) * parallax_fg * p * scale_y
                     if travel_path == "arc":
-                        dx = (cx1 - cx0) * scale_x
-                        dy = (cy1 - cy0) * scale_y
-                        dist = math.hypot(dx, dy)
-                        if dist > 1e-6:
-                            px, py = -dy / dist, dx / dist
-                            off = math.sin(math.pi * p) * dist * 0.25 * parallax_fg
-                            offx += px * off
-                            offy += py * off
+                        camx, camy = motion.arc_path((cx0, cy0), (cx1, cy1), p, strength=0.25)
+                    else:
+                        camx = cx0 + (cx1 - cx0) * p
+                        camy = cy0 + (cy1 - cy0) * p
+                    offx = (camx - cx0) * parallax_fg * scale_x
+                    offy = (camy - cy0) * parallax_fg * scale_y
                 x_pos = int(round(xb + offx))
                 y_pos = int(round(yb + offy))
                 x_pos = max(0, min(x_pos, Wout - nw))


### PR DESCRIPTION
## Summary
- remove sinusoidal drift options in favor of deterministic `motion.subtle_drift`
- use `motion.arc_path` for foreground arc travel to avoid manual math
- drop `--bg-drift-*` and `--fg-drift-*` CLI flags and update docs

## Testing
- `ruff check .` *(fails: unused imports, E741 ambiguous variables, etc.)*
- `mypy .` *(fails: missing stubs, typing errors)*
- `pytest -q` *(fails: ImportError: libGL.so.1 missing)*
- `python -m ken_burns_reel . --dry-run` *(fails: ImportError: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a6e18912c8321a51c73aa863c8a7d