### PR TITLE
Add perf profile and moviepy v1 compatibility

### DIFF
--- a/docs/LOOK.md
+++ b/docs/LOOK.md
@@ -1,18 +1,31 @@
-
-# Arc vs Linear Motion
-
-Comparative XY plot of linear and arc interpolation used for camera moves.
-
-The illustrative plot is generated during documentation builds and is not stored in the repository.
-=======
 # LOOK
 
-Golden frames for `overlay_lift` transition can be generated locally using
-`tests/test_overlay_lift.py`. Images are omitted from the repository to avoid
-binary assets.
+Reference visualisations used in documentation are generated locally and saved under `artifacts/` (ignored by git).
 
-# LOOK samples
+## Arc vs Linear motion
 
-Sample outputs can be generated locally and stored under `artifacts/` (ignored in git).
+Generate a comparison plot for camera paths:
 
+```bash
+python - <<'PY'
+import numpy as np, matplotlib.pyplot as plt
+from ken_burns_reel import motion
 
+p = np.linspace(0, 1, 100)
+arc = np.array([motion.arc_path((0, 0), (1, 0), t) for t in p])
+plt.plot(p, np.zeros_like(p), label="linear")
+plt.plot(p, arc[:, 1], label="arc")
+plt.legend()
+plt.savefig("artifacts/arc_vs_linear.png")
+PY
+```
+
+## overlay_lift transition frames
+
+Golden frames for `overlay_lift` can be generated via tests:
+
+```bash
+pytest tests/test_overlay_lift.py --look
+```
+
+All outputs will appear in the local `artifacts/` directory.

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import sys
 
@@ -9,6 +10,7 @@ import yaml
 
 from .bin_config import resolve_imagemagick, resolve_tesseract
 from .builder import make_filmstrip, _export_profile, _fit_audio_clip
+from .layers import shadow_cache_stats
 from .ocr import verify_tesseract_available
 
 
@@ -178,6 +180,15 @@ def _run_oneclick(args: argparse.Namespace, target_size: tuple[int, int]) -> Non
         prof = _export_profile(args.profile, args.codec, target_size)
         if prof.get("resize"):
             clip = clip.resize(newsize=prof["resize"])
+        if args.profile == "perf":
+            hits, misses = shadow_cache_stats()
+            total = hits + misses
+            rate = hits / total if total else 0.0
+            logging.info(
+                "shadow_cache hit-rate: %.2f%% (%d/%d)", rate * 100, hits, total
+            )
+            clip_count = sum(1 for _ in clip.iter_clips())
+            logging.info("VideoClip count: %d", clip_count)
         clip.write_videofile(
             out_path,
             fps=prof["fps"],
@@ -355,7 +366,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--profile",
-        choices=["preview", "social", "quality"],
+        choices=["preview", "social", "quality", "perf"],
         default="social",
         help="Preset eksportu",
     )
@@ -655,6 +666,15 @@ def main(argv: list[str] | None = None) -> None:
         prof = _export_profile(args.profile, args.codec, target_size)
         if prof.get("resize"):
             clip = clip.resize(newsize=prof["resize"])
+        if args.profile == "perf":
+            hits, misses = shadow_cache_stats()
+            total = hits + misses
+            rate = hits / total if total else 0.0
+            logging.info(
+                "shadow_cache hit-rate: %.2f%% (%d/%d)", rate * 100, hits, total
+            )
+            clip_count = sum(1 for _ in clip.iter_clips())
+            logging.info("VideoClip count: %d", clip_count)
         clip.write_videofile(
             out_path,
             fps=prof["fps"],
@@ -769,6 +789,7 @@ def main(argv: list[str] | None = None) -> None:
             overlay_frame_color=args.overlay_frame_color,
             bg_offset=args.bg_offset,
             fg_offset=args.fg_offset,
+            seed=args.seed,
             bg_drift_zoom=args.bg_drift_zoom,
             bg_drift_speed=args.bg_drift_speed,
             fg_drift_zoom=args.fg_drift_zoom,
@@ -788,6 +809,15 @@ def main(argv: list[str] | None = None) -> None:
         prof = _export_profile(args.profile, args.codec, target_size)
         if prof.get("resize"):
             clip = clip.resize(newsize=prof["resize"])
+        if args.profile == "perf":
+            hits, misses = shadow_cache_stats()
+            total = hits + misses
+            rate = hits / total if total else 0.0
+            logging.info(
+                "shadow_cache hit-rate: %.2f%% (%d/%d)", rate * 100, hits, total
+            )
+            clip_count = sum(1 for _ in clip.iter_clips())
+            logging.info("VideoClip count: %d", clip_count)
         clip.write_videofile(
             out_path,
             fps=prof["fps"],

--- a/ken_burns_reel/builder.py
+++ b/ken_burns_reel/builder.py
@@ -1530,6 +1530,7 @@ def _export_profile(profile: str, codec: str, target_size: Tuple[int, int]) -> D
         "preview": {"crf": "31", "preset": "veryfast", "audio_bitrate": "96k", "fps": 24},
         "social": {"crf": "26", "preset": "medium", "audio_bitrate": "128k", "fps": 30},
         "quality": {"crf": "21", "preset": "slow", "audio_bitrate": "192k", "fps": 30},
+        "perf": {"crf": "36", "preset": "ultrafast", "audio_bitrate": "64k", "fps": 30},
     }[profile]
     resize = None
     if profile == "preview" and target_size == (1080, 1920):

--- a/ken_burns_reel/layers.py
+++ b/ken_burns_reel/layers.py
@@ -10,6 +10,7 @@ import hashlib
 
 # simple in-memory cache for page effects
 _SHADOW_CACHE: Dict[Tuple[str, float, int, Tuple[int, int]], np.ndarray] = {}
+_SHADOW_STATS = {"hits": 0, "misses": 0}
 
 
 def _premultiply(arr: np.ndarray) -> np.ndarray:
@@ -50,7 +51,9 @@ def page_shadow(
     key_hash = hashlib.sha1(src.tobytes()).hexdigest()
     key = (key_hash, float(strength), int(blur), tuple(offset_xy))
     if key in _SHADOW_CACHE:
+        _SHADOW_STATS["hits"] += 1
         return _SHADOW_CACHE[key].copy()
+    _SHADOW_STATS["misses"] += 1
 
     ox, oy = offset_xy
     pad_l = max(blur - min(0, ox), 0)
@@ -70,3 +73,8 @@ def page_shadow(
 
     _SHADOW_CACHE[key] = canvas
     return canvas.copy()
+
+
+def shadow_cache_stats() -> Tuple[int, int]:
+    """Return ``(hits, misses)`` for page shadow cache."""
+    return _SHADOW_STATS["hits"], _SHADOW_STATS["misses"]

--- a/ken_burns_reel/transitions.py
+++ b/ken_burns_reel/transitions.py
@@ -167,8 +167,13 @@ def fg_fade(panel_clip, duration: float, ease: str = "inout", fg_offset: float =
         p = ease_fn((t + fg_offset) / max(1e-6, duration))
         return mask.get_frame(t) * (1 - p)
 
-    faded_mask = mask.with_updated_frame_function(mask_frame)
-    return panel_clip.with_mask(faded_mask)
+    if hasattr(mask, "with_updated_frame_function"):
+        faded_mask = mask.with_updated_frame_function(mask_frame)
+    else:  # moviepy <2
+        faded_mask = mask.fl(lambda gf, t: mask_frame(t))
+    if hasattr(panel_clip, "with_mask"):
+        return panel_clip.with_mask(faded_mask)
+    return panel_clip.set_mask(faded_mask)
 
 
 def smear_bg_crossfade_fg(

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -2,19 +2,29 @@ import numpy as np
 
 try:
     from moviepy import ColorClip, CompositeVideoClip
-except ModuleNotFoundError:  # pragma: no cover
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
     from moviepy.editor import ColorClip, CompositeVideoClip
 
 from ken_burns_reel.transitions import fg_fade, _get_ease_fn
 
 
+def _set_duration(clip, duration):
+    return getattr(clip, "with_duration", clip.set_duration)(duration)
+
+
+def _set_fps(clip, fps):
+    return getattr(clip, "with_fps", clip.set_fps)(fps)
+
+
+def _set_opacity(clip, opacity):
+    return getattr(clip, "with_opacity", clip.set_opacity)(opacity)
+
+
 def test_fg_fade_keeps_background():
-    bg = ColorClip(size=(4, 4), color=(0, 0, 0)).with_duration(1).with_fps(1)
-    fg = (
-        ColorClip(size=(4, 4), color=(255, 0, 0))
-        .with_duration(1)
-        .with_fps(1)
-        .with_opacity(1)
+    bg = _set_fps(_set_duration(ColorClip(size=(4, 4), color=(0, 0, 0)), 1), 1)
+    fg = _set_opacity(
+        _set_fps(_set_duration(ColorClip(size=(4, 4), color=(255, 0, 0)), 1), 1),
+        1,
     )
     faded = fg_fade(fg, 1)
     comp = CompositeVideoClip([bg, faded])


### PR DESCRIPTION
## Summary
- add perf export profile and wire seed through overlay sequence
- log shadow cache hit-rate and clip count when using perf profile
- ensure transitions and tests work with moviepy<2
- document how to regenerate LOOK artifacts

## Testing
- `pytest -q` (10 failed, 27 passed, 11 skipped)
- `ruff check .` (errors: F401, E741, etc.)
- `mypy .` (missing library stubs)
- `python -m ken_burns_reel . --dry-run` (unrecognized arguments: --dry-run)


------
https://chatgpt.com/codex/tasks/task_e_689a6e34163483219cd9cc871e4700aa