### PR TITLE
feat: add output flag with auto naming

### DIFF
--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -31,6 +31,16 @@ python -m ken_burns_reel . --mode panels ^
   --profile social
 ```
 
+## Custom output path
+
+Use `--output` to choose a file name or target directory. Existing paths are
+auto-suffixed with a timestamp or counter to avoid overwriting.
+
+```bash
+python -m ken_burns_reel . --mode panels --output out/
+python -m ken_burns_reel . --mode panels --output "out/custom.mp4"
+```
+
 ## One-click mode
 
 **PowerShell**


### PR DESCRIPTION
## Summary
- add --output CLI flag to specify output file or directory
- ensure video renders never overwrite existing files via _resolve_out_path
- document custom output usage in CLI examples

## Testing
- `pytest -q` *(fails: make_panels_overlay_sequence errors, etc.)*
- `ruff check . || true`
- `mypy . || true`
- `python -m ken_burns_reel . --dry-run || true` *(unrecognized argument --dry-run)*

------
https://chatgpt.com/codex/tasks/task_e_689a72d708b0832192e4902ccf3d05de