### PR TITLE
Diagnostics + KB bootstrap: CLI map, env probe, CI, tests summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: '3.10'
+      - name: Install system deps
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr imagemagick ffmpeg libgl1
+      - name: Install
+        run: pip install -e .[dev]
+      - name: Diagnose env
+        run: python tools/diagnose_env.py
+      - name: Ruff
+        run: ruff check .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest -q --junitxml=tests_report.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: junit
+          path: tests_report.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Automatyczne Generowanie Wideo z Obrazków
 
+![CI](https://github.com/PKrokosz/Automatyczne-generowanie-video-z-obrazk-w/actions/workflows/ci.yml/badge.svg)
+
 Skrypt w Pythonie do automatycznego tworzenia wideo z serii obrazków, wykorzystujący efekt **Ken Burns**, przewijanie w osi X/Y, dodawanie dźwięku, przejścia oraz napisy z OCR.
 
 ## Table of Contents
@@ -9,6 +11,7 @@ Skrypt w Pythonie do automatycznego tworzenia wideo z serii obrazków, wykorzyst
 - [Tests](#tests)
 - [Contributing](#contributing)
 - [License](#license)
+- [How to read this repo](#how-to-read-this-repo)
 
 ## Features
 - Efekt Ken Burns (zoom i przesunięcie) dla pojedynczych paneli.
@@ -113,3 +116,7 @@ Zasady współpracy opisuje [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 Projekt na licencji MIT — patrz [LICENSE](LICENSE).
+
+## How to read this repo
+
+Szczegółowa dokumentacja znajduje się w katalogu [docs/KB](docs/KB/index.md).

--- a/docs/KB/architecture.md
+++ b/docs/KB/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+- `color`: Colour space utilities.
+- `transitions`: Video transitions.
+- `utils`: Utility helpers for video creation.
+- `audio`: Audio processing helpers.
+- `__init__`: Ken Burns reel package.
+- `builder`: Core building logic for the Ken Burns reel.
+- `panels`: 
+- `ocr`: OCR helpers.
+- `cli`: 
+- `motion`: 
+- `layers`: Layer effects utilities.
+- `__main__`: Command line interface for ken_burns_reel.
+- `config`: Static configuration for ken_burns_reel.
+- `captions`: Caption rendering utilities.
+- `focus`: Focus point detection.
+- `bin_config`: Helpers to resolve external binary paths.

--- a/docs/KB/cli_reference.md
+++ b/docs/KB/cli_reference.md
@@ -1,0 +1,97 @@
+# CLI Reference
+| Flag | Type | Default | Help |
+|------|------|---------|------|
+| folder | str | None | Input folder with images and audio |
+| --preset | str | [] | Path to YAML preset overriding defaults |
+| --tesseract | str | None | Path to Tesseract binary |
+| --magick | str | None | Path to ImageMagick binary |
+| --output | str | None | Path to MP4 file or output directory. If existing, a timestamp/counter is appended. |
+| --out-naming | str | auto | Naming policy for output file |
+| --out-prefix | str |  | Prefix for auto/custom naming |
+| --export-panels | str | None | Export detected panels to folder |
+| --oneclick | str | None | Tryb one-click: auto video from pages and audio |
+| --validate | str | None | Validate arguments and exit |
+| --deterministic | str | None | Force deterministic build |
+| --export-mode | str | rect | Panel export mode |
+| --mode | str | None | classic: dotychczasowy montaż; panels: ruch kamery po panelach komiksu; panels-items: montaż z pojedynczych paneli; panels-overlay: tło strona, foreground panel |
+| --limit-items | int | 999 | Limit liczby paneli w overlay |
+| --tight-border | int | 1 | Erozja konturu w eksporcie mask (px) |
+| --feather | int | 1 | Feather alpha w eksporcie mask (px) |
+| --roughen | float | 0.15 | Nieregularność krawędzi maski (0..1) |
+| --roughen-scale | int | 24 | Skala szumu dla roughen |
+| --enhance | str | comic | Tryb poprawy paneli |
+| --enhance-strength | float | 1.0 | Siła enhance |
+| --shadow | _parallax_type | 0.2 | Opacity cienia pod panelem |
+| --shadow-blur | _clamp_nonneg_int | 12 | Rozmycie cienia (px) |
+| --shadow-offset | _clamp_nonneg_int | 3 | Offset cienia (px) |
+| --dwell | float | 1.0 | Czas zatrzymania na panelu (s) |
+| --travel | float | 0.6 | Czas przejazdu między panelami (s) |
+| --transition-duration | float | 0.3 | Długość przejścia/crossfadu między panelami (s) |
+| --trans-dur | float | argparse.SUPPRESS |  |
+| --xfade | float | argparse.SUPPRESS |  |
+| --settle | float | 0.14 | Długość micro-holdu (s) |
+| --travel-ease | str | inout | Profil jazdy kamery |
+| --dwell-scale | float | 1.0 | Globalne skalowanie czasu zatrzymania po zważeniu |
+| --align-beat | str | None | Wyrównaj start stron do najbliższego beatu |
+| --debug-panels | str | None | Tryb debug – zapisuje plik panels_debug.jpg z wykrytymi ramkami i kończy działanie. |
+| --audio-fit | str | trim | Jak dopasować audio do długości wideo |
+| --audio | str | None | Ścieżka do pliku audio |
+| --audio-gain | float | 0.0 | Wzmocnienie ścieżki audio (dB) |
+| --dwell-mode | str | first | Na ilu panelach zatrzymywać się w pełni |
+| --bg-mode | str | blur | Underlay pod stroną |
+| --bg-blur | float | 8.0 | Rozmycie tła |
+| --bg-tex | str | vignette | Tekstura tła |
+| --overlay-edge | str | feather | Typ krawędzi panelu overlay |
+| --overlay-edge-strength | float | 0.6 | Siła efektu krawędzi overlay |
+| --page-scale | _page_scale_type | 0.92 | Skala foreground (mniejsza niż 1.0 = widać tło) |
+| --bg-parallax | _parallax_type | None | Siła paralaksy tła podczas travelu |
+| --panel-bleed | _nonneg_int | 24 | Margines przy kadrowaniu panelu (px) |
+| --zoom-max | _zoom_max_type | 1.06 | Maksymalne dodatkowe przybliżenie dla małego tekstu |
+| --trans | str | smear | Przejście między panelami w trybie panels-items |
+| --smear-strength | float | 1.0 | Siła smuga dla przejścia smear |
+| --profile | str | social | Preset eksportu |
+| --preview | str | None | Skrót dla --profile preview |
+| --codec | str | h264 | Kodek wideo |
+| --size | str | None | Docelowy rozmiar WxH |
+| --aspect | str | choices=['9:16', '16:9', '1:1'] | Proporcje (z --height) |
+| --height | int | None | Wysokość dla --aspect |
+| --overlay-fit | _overlay_fit_type | None | Udział wysokości kadru dla panelu |
+| --overlay-margin | int | None | Margines wokół panelu |
+| --overlay-mode | str | anchored | Pozycjonowanie panelu (anchored=centered to page pos, center=na środku) |
+| --overlay-scale | float | None | Mnożnik skali panelu względem lokalnej skali tła |
+| --bg-source | str | page | Źródło tła: page (crop strony z toningiem), blur, stretch, gradient |
+| --bg-tone-strength | _parallax_type | 0.7 | Siła tonowania tła |
+| --fg-shadow | _parallax_type | None | Opacity cienia pod panelem (0..1, 0 = brak cienia) |
+| --fg-shadow-blur | _clamp_nonneg_int | None | Rozmycie cienia fg |
+| --fg-shadow-offset | _clamp_nonneg_int | None | Offset cienia fg |
+| --fg-glow | _parallax_type | None | Siła poświaty panelu |
+| --fg-glow-blur | _clamp_nonneg_int | None | Rozmycie poświaty |
+| --fg-shadow-mode | str | soft | Tryb cienia foreground |
+| --parallax-bg | _parallax_type | None | Paralaksa tła overlay |
+| --parallax-fg | _parallax_fg_type | None | Paralaksa panelu |
+| --gutter-thicken | _clamp_nonneg_int | 2 | Pogrubienie korytarzy przy eksporcie masek (px) |
+| --min-panel-area-ratio | float | 0.03 | Minimalny udział panelu w stronie |
+| --debug-overlay | str | None | Zapisz PNG z overlay dla pierwszych segmentów |
+| --timing-profile | str | None | Profil czasu trwania segmentów |
+| --bpm | int | None | Ustaw tempo utworu (beats per minute) |
+| --beats-per-panel | float | 2.0 | Ile beatów na panel |
+| --beats-travel | float | 0.5 | Ile beatów przejazdu |
+| --readability-ms | int | 1400 | Minimalna ekspozycja panelu (ms) |
+| --min-dwell | float | 1.0 | Minimalny czas zatrzymania (s) |
+| --max-dwell | float | 1.8 | Maksymalny czas zatrzymania (s) |
+| --settle-min | float | 0.12 | Minimalny czas settle (s) |
+| --settle-max | float | 0.22 | Maksymalny czas settle (s) |
+| --quantize | str | off | Przyciągaj starty do siatki nut |
+| --overlay-pop | float | 1.0 | Początkowa skala overlay dla efektu pop-in |
+| --overlay-jitter | float | 0.0 | Subtelny mikro-ruch overlay (px) |
+| --overlay-frame-px | _clamp_nonneg_int | 0 | Grubość ramki overlay (px) |
+| --overlay-frame-color | str | #000000 | Kolor ramki overlay w formacie #RRGGBB |
+| --bg-offset | float | 0.0 | Opóźnienie ruchu tła (s) |
+| --fg-offset | float | 0.0 | Opóźnienie ruchu panelu (s) |
+| --seed | int | 0 | Seed deterministycznego driftu |
+| --travel-path | str | linear | Tor przejazdu kamery |
+| --deep-bottom-glow | float | 0.0 | Poświata od dołu (0..1) |
+| --page-scale-overlay | _page_scale_type | 1.0 | Skala strony przy overlay |
+| --bg-vignette | _parallax_type | 0.15 | Siła winiety tła |
+| --look | str | none | Preset koloru tła |
+| --items-from | str | None | Folder z maskami paneli |

--- a/docs/KB/code_quality.md
+++ b/docs/KB/code_quality.md
@@ -1,0 +1,11 @@
+# Code Quality
+
+## Ruff
+
+`ruff check .` reported 144 issues, mainly `E501` line length violations in tests such as `tests/video/test_new_features.py` and `tools/diagnose_env.py`.
+
+## Mypy
+
+`mypy .` reported 57 type errors across modules like `ken_burns_reel/builder.py` and `ken_burns_reel/__main__.py`.
+
+These checks run in CI but do not block development yet.

--- a/docs/KB/env.md
+++ b/docs/KB/env.md
@@ -1,0 +1,26 @@
+# Environment
+
+The project relies on external binaries for rendering and OCR. Discovery is handled by `ken_burns_reel/bin_config.py` which searches CLI flags, environment variables and finally `$PATH`.
+
+| Binary | Resolution order |
+|--------|-----------------|
+| ImageMagick `magick` | `--magick` → `IMAGEMAGICK_BINARY` → `shutil.which("magick")` |
+| Tesseract OCR | `--tesseract` → `TESSERACT_BINARY` → `pytesseract.pytesseract.tesseract_cmd` → `shutil.which("tesseract")` |
+| FFmpeg | probed via `shutil.which("ffmpeg")` in tools/diagnose_env.py |
+
+Overrides are stored back in environment variables so subsequent calls reuse the resolved paths.
+
+A helper script `tools/diagnose_env.py` prints detected paths and versions:
+
+```bash
+python tools/diagnose_env.py
+```
+
+## Ubuntu setup
+
+```bash
+sudo apt-get update
+sudo apt-get install -y tesseract-ocr imagemagick ffmpeg libgl1
+```
+
+The `libgl1` package is required by OpenCV to avoid `ImportError: libGL.so.1`.

--- a/docs/KB/index.md
+++ b/docs/KB/index.md
@@ -1,0 +1,10 @@
+# Knowledge Base
+
+- [Architecture](architecture.md)
+- [Modules](modules.md)
+- [CLI Reference](cli_reference.md)
+- [Environment](env.md)
+- [Code Quality](code_quality.md)
+- [Tests Report](tests_report.md)
+- [Transitions](transitions.md)
+- [I/O Conventions](io_conventions.md)

--- a/docs/KB/io_conventions.md
+++ b/docs/KB/io_conventions.md
@@ -1,0 +1,11 @@
+# I/O Conventions
+
+Output video files follow a human-readable naming scheme. The `--out-naming` flag controls behaviour:
+
+| Mode | Description |
+|------|-------------|
+| `auto` (default) | `<out-prefix><input-folder>-<mode>_<timestamp>.mp4` in the target directory |
+| `keep` | legacy behaviour using provided `--output` path or `final_video.mp4` |
+| `custom` | `<out-prefix>_<timestamp>.mp4` |
+
+Use `--out-prefix` to prepend a slug.

--- a/docs/KB/modules.md
+++ b/docs/KB/modules.md
@@ -1,0 +1,74 @@
+# Modules
+### `color`
+- `srgb_to_linear16`: Convert 16‑bit sRGB values to linear light floats.
+- `linear16_to_srgb`: Convert linear light floats back to 16‑bit sRGB values.
+### `transitions`
+- `ease_in_out`: Cosine ease-in-out for ``t`` in [0,1].
+- `ease_in`: Cosine ease-in for ``t`` in [0,1].
+- `ease_out`: Cosine ease-out for ``t`` in [0,1].
+- `slide_transition`: Simple horizontal slide transition between clips.
+- `smear_transition`: Directional smear (pseudo motion blur) between clips.
+- `whip_pan_transition`: Whip-pan style transition with easing and brightness dip.
+- `fg_fade`: Fade only the foreground alpha of ``panel_clip``.
+- `smear_bg_crossfade_fg`: Smear transition for backgrounds with foreground crossfade.
+- `overlay_lift`: Lift-in effect for overlay panels.
+### `utils`
+- `smart_crop`: Crop image to target aspect ratio while keeping center.
+- `gaussian_blur`: Apply Gaussian blur with validated kernel parameters.
+### `audio`
+- `extract_beats`: Return beat times for an audio file.
+### `__init__`
+- `make_filmstrip`: 
+### `builder`
+- `ease_in_out`: Cosine ease-in-out for t in [0,1].
+- `ease_in`: Cosine ease-in for t in [0,1].
+- `ease_out`: Cosine ease-out for t in [0,1].
+- `apply_clahe_rgb`: 
+- `enhance_panel`: Enhance RGBA panel; process RGB and keep alpha.
+- `make_panels_cam_clip`: Animate camera between comic panels detected in the image.
+- `make_panels_cam_sequence`: Buduje jeden film, sklejając panel-camera clippy dla wszystkich stron.
+- `make_panels_items_sequence`: Build a sequence from pre-cropped panel images.
+- `compute_segment_timing`: 
+- `make_panels_overlay_sequence`: Render overlay sequence with static foreground panels.
+- `ken_burns_scroll`: Create a single Ken Burns style clip.
+- `make_filmstrip`: Build final video from assets in *input_folder*.
+### `panels`
+- `alpha_bbox`: Return bounding box of non-zero alpha in RGBA array.
+- `fill_holes`: Fill holes inside a binary mask using flood fill from the border.
+- `roughen_alpha`: Add small irregularities to the mask edge.
+- `detect_panels`: 
+- `order_panels_lr_tb`: 
+- `export_panels`: Detect panels in *image_path* and export them to *out_dir*.
+- `debug_detect_panels`: 
+### `ocr`
+- `extract_caption`: Extract text from an image using pytesseract.
+- `verify_tesseract_available`: Ensure tesseract binary is available or raise an error.
+- `page_ocr_data`: Return raw OCR data for an entire page.
+- `text_boxes_stats`: Return basic stats about OCR-detected word boxes in *img*.
+### `cli`
+- `build_parser`: 
+- `validate_args`: 
+- `main`: 
+### `motion`
+- `arc_path`: Interpolate between ``start`` and ``end`` along an arc.
+- `DriftParams`: 
+- `subtle_drift`: Return deterministic subtle drift parameters.
+- `apply_transform`: Apply zoom/translation/rotation drift to ``img``.
+### `layers`
+- `page_shadow`: Apply drop shadow to ``img`` and return RGBA with premultiplied alpha.
+- `shadow_cache_stats`: Return ``(hits, misses)`` for page shadow cache.
+### `__main__`
+- `parse_args`: 
+- `main`: 
+### `captions`
+- `sanitize_caption`: 
+- `is_caption_meaningful`: 
+- `render_caption_clip`: Create a TextClip for *text* or return ``None`` if rendering fails.
+- `overlay_caption`: Overlay *text* caption onto *clip* if possible.
+### `focus`
+- `detect_focus_point`: Detect a point of interest in an image.
+### `bin_config`
+- `resolve_imagemagick`: Resolve path to ImageMagick ``magick`` executable.
+- `resolve_tesseract`: Resolve path to the Tesseract binary.
+
+## Cross-imports

--- a/docs/KB/tests_report.md
+++ b/docs/KB/tests_report.md
@@ -1,0 +1,8 @@
+# Tests Report
+
+`pytest -q` results (`32 passed`, `10 failed`, `10 skipped`):
+
+- overlay tests: `tests/overlay/test_overlay_bg.py` (2 failures), `tests/overlay/test_panels_items.py` (8 failures)
+- other suites (`tests/test_cli.py`, `tests/test_transitions.py`, `tests/test_io_naming.py`) passed
+
+Full log generated as `tests_report.xml` during CI.

--- a/docs/KB/transitions.md
+++ b/docs/KB/transitions.md
@@ -1,0 +1,9 @@
+# Transitions
+
+The `ken_burns_reel/transitions.py` module implements several transitions. Notable is `fg_fade` which fades only the foreground mask while leaving the background static.
+
+```python
+from ken_burns_reel.transitions import fg_fade
+```
+
+The CLI enforces a minimum panel exposure of 1400 ms via the `--readability-ms` option; passing `--validate` or `--deterministic` does not reduce this guard.

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -41,6 +41,18 @@ python -m ken_burns_reel . --mode panels --output out/
 python -m ken_burns_reel . --mode panels --output "out/custom.mp4"
 ```
 
+### Automatic naming
+
+```bash
+python -m ken_burns_reel . --mode panels --out-naming auto --out-prefix demo-
+```
+
+### Validation and deterministic mode
+
+```bash
+python -m ken_burns_reel . --mode classic --validate --deterministic
+```
+
 ## One-click mode
 
 **PowerShell**

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+python_version = 3.10

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+line-length = 88
+[lint]
+select = ["E", "F"]

--- a/scripts/extract_cli.py
+++ b/scripts/extract_cli.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+MAIN = Path('ken_burns_reel/__main__.py')
+KB = Path('docs/KB/cli_reference.md')
+
+
+def extract():
+    tree = ast.parse(MAIN.read_text())
+    args = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == 'add_argument':
+            flag = node.args[0].value if node.args else ''
+            default = None
+            help_str = ''
+            arg_type = 'str'
+            for kw in node.keywords:
+                if kw.arg == 'default':
+                    try:
+                        default = ast.literal_eval(kw.value)
+                    except Exception:  # noqa: BLE001
+                        default = ast.unparse(kw.value)
+                elif kw.arg == 'help':
+                    help_str = kw.value.value if isinstance(kw.value, ast.Constant) else ''
+                elif kw.arg == 'type':
+                    arg_type = getattr(kw.value, 'id', 'str')
+                elif kw.arg == 'choices':
+                    default = f"choices={ast.literal_eval(kw.value)}"
+            args.append((flag, arg_type, default, help_str))
+    lines = ['# CLI Reference', '| Flag | Type | Default | Help |', '|------|------|---------|------|']
+    for flag, arg_type, default, help_str in args:
+        lines.append(f"| {flag} | {arg_type} | {default} | {help_str} |")
+    KB.write_text('\n'.join(lines))
+
+
+if __name__ == '__main__':
+    extract()

--- a/scripts/gen_kb.py
+++ b/scripts/gen_kb.py
@@ -1,0 +1,71 @@
+import ast
+import os
+from collections import defaultdict
+from pathlib import Path
+
+PACKAGE = Path('ken_burns_reel')
+KB_DIR = Path('docs/KB')
+
+
+def module_tree():
+    tree = {}
+    for path in PACKAGE.rglob('*.py'):
+        rel = path.relative_to(PACKAGE).with_suffix('')
+        parts = rel.parts
+        node = tree
+        for p in parts[:-1]:
+            node = node.setdefault(p, {})
+        node.setdefault('__files__', []).append(rel)
+    return tree
+
+
+def write_architecture(tree, prefix=''):
+    lines = []
+    for name, subtree in sorted(tree.items()):
+        if name == '__files__':
+            for f in subtree:
+                mod_path = PACKAGE / (str(f) + '.py')
+                doc = ast.get_docstring(ast.parse(mod_path.read_text())) or ''
+                first = doc.splitlines()[0] if doc else ''
+                lines.append(f"- `{f}`: {first}")
+        else:
+            lines.append(f"{prefix}- {name}/")
+            lines.extend(write_architecture(subtree, prefix + '  '))
+    return lines
+
+
+def api_map():
+    lines = []
+    imports = defaultdict(set)
+    for path in PACKAGE.rglob('*.py'):
+        mod = path.relative_to(PACKAGE).with_suffix('')
+        tree = ast.parse(path.read_text())
+        publics = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and not node.name.startswith('_'):
+                doc = ast.get_docstring(node) or ''
+                first = doc.splitlines()[0] if doc else ''
+                publics.append((node.name, first))
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and node.module.startswith('ken_burns_reel'):
+                    imports[str(mod)].add(node.module)
+        if publics:
+            lines.append(f"### `{mod}`")
+            for name, doc in publics:
+                lines.append(f"- `{name}`: {doc}")
+    # Imports map
+    lines.append("\n## Cross-imports")
+    for mod, imps in sorted(imports.items()):
+        lines.append(f"- `{mod}` -> {', '.join(sorted(imps))}")
+    return lines
+
+
+def main():
+    arch_lines = ['# Architecture'] + write_architecture(module_tree())
+    (KB_DIR / 'architecture.md').write_text('\n'.join(arch_lines))
+    mod_lines = ['# Modules'] + api_map()
+    (KB_DIR / 'modules.md').write_text('\n'.join(mod_lines))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_io_naming.py
+++ b/tests/test_io_naming.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from pathlib import Path
+from types import SimpleNamespace
+
+from ken_burns_reel.__main__ import _resolve_out_path
+
+
+def test_auto_naming(tmp_path: Path) -> None:
+    args = SimpleNamespace(
+        out_naming="auto",
+        out_prefix="test-",
+        output=str(tmp_path),
+        folder=str(tmp_path),
+        mode="classic",
+    )
+    path = _resolve_out_path(args, "final_video.mp4", str(tmp_path))
+    assert path.startswith(str(tmp_path)), path
+    assert Path(path).name.startswith("test-")
+
+
+def test_keep_naming(tmp_path: Path) -> None:
+    args = SimpleNamespace(
+        out_naming="keep",
+        out_prefix="",
+        output=str(tmp_path / "out.mp4"),
+        folder=str(tmp_path),
+        mode="classic",
+    )
+    path = _resolve_out_path(args, "final_video.mp4", str(tmp_path))
+    assert Path(path).name.startswith("out")

--- a/tools/diagnose_env.py
+++ b/tools/diagnose_env.py
@@ -1,0 +1,35 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+BINARIES = {
+    "tesseract": ["tesseract", "--version"],
+    "imagemagick": ["magick", "-version"],
+    "ffmpeg": ["ffmpeg", "-version"],
+}
+
+
+def check_bin(name: str, cmd: list[str]) -> None:
+    path = shutil.which(cmd[0])
+    if not path:
+        print(f"{name}: NOT FOUND")
+        return
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True).splitlines()[0]
+    except Exception as e:  # noqa: BLE001
+        out = f"error invoking: {e}"
+    print(f"{name}: {path} -> {out}")
+
+
+def main() -> None:
+    for name, cmd in BINARIES.items():
+        check_bin(name, cmd)
+    try:
+        libgl_path = next(Path("/usr/lib").rglob("libGL.so.1"))
+        print(f"libGL: {libgl_path}")
+    except StopIteration:
+        print("libGL: NOT FOUND")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `--out-naming`/`--out-prefix` options and auto naming logic
- generate knowledge base docs (architecture, modules, CLI, env, tests)
- add environment probe script and CI workflow

## Testing
- `python tools/diagnose_env.py`
- `ruff check .` *(fails: 144 issues)*
- `mypy .` *(fails: 57 errors)*
- `pytest -q --junitxml=tests_report.xml` *(32 passed, 10 failed, 10 skipped)*

## Follow-up
- Fix ruff and mypy findings
- Address failing overlay tests
- Add ImageMagick detection in diagnose_env


------
https://chatgpt.com/codex/tasks/task_e_689a7674921c8321bc75f6800b50caac