### PR TITLE
fix: correct mask holes ratio in panel export

### DIFF
--- a/ken_burns_reel/panels.py
+++ b/ken_burns_reel/panels.py
@@ -312,7 +312,8 @@ def export_panels(
                 mask_crop = roughen_alpha(mask_crop, roughen, roughen_scale)
             alpha = mask_crop
             bin_alpha = (alpha > 127).astype(np.uint8)
-            holes_ratio = 1.0 - float(bin_alpha.sum()) / bin_alpha.size
+            panel_area = max(1, (m[y0:y1, x0:x1] > 0).sum())
+            holes_ratio = 1.0 - float(bin_alpha.sum()) / float(panel_area)
             if holes_ratio > mask_rect_fallback:
                 alpha = np.full_like(alpha, 255)
             rgba = np.dstack([crop, alpha])


### PR DESCRIPTION
## Summary
- ensure panel mask hole ratio ignores bleed areas

## Testing
- `pytest tests/overlay/test_panels_items.py::test_export_panels_rect_and_mask -q`


------
https://chatgpt.com/codex/tasks/task_e_689a81a1e50483218fac88a4458733c6