### PR TITLE
feat: add min-read validation for segment pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Below is the complete list of command-line options for `python -m ken_burns_reel
 | `--bpm` | `` | `None` | Ustaw tempo utworu (beats per minute) |
 | `--beats-per-panel` | `` | `2.0` | Ile beatów na panel |
 | `--beats-travel` | `` | `0.5` | Ile beatów przejazdu |
-| `--readability-ms` | `` | `1400` | Minimalna ekspozycja panelu (ms) |
+| `--readability-ms` | `` | `1400` | Minimalna ekspozycja panelu (ms, min 1400) |
 | `--min-dwell` | `` | `1.0` | Minimalny czas zatrzymania (s) |
 | `--max-dwell` | `` | `1.8` | Maksymalny czas zatrzymania (s) |
 | `--settle-min` | `` | `0.12` | Minimalny czas settle (s) |
@@ -178,7 +178,9 @@ Below is the complete list of command-line options for `python -m ken_burns_reel
 | `--items-from` | `` | `None` | Folder z maskami paneli |
 
 ## Advanced Options and Validation
-- `--validate` parses arguments and exits after reporting validation errors.
+- `--validate` parses arguments and exits after reporting validation errors. It
+  verifies that flags such as `--dwell`, `--min-dwell`, and `--beats-per-panel`
+  do not shorten visible segments below the 1.4 s readability guard.
 - `--deterministic` seeds Python and NumPy RNGs (use with `--seed`) for reproducible motion.
 - Caching: `layers.page_shadow` caches generated shadows; cache stats are logged in `--profile perf`.
 - Tests use golden images and JSON logs; the `--look` option in `tests/test_overlay_lift.py` writes reference frames for docs/LOOK.md.

--- a/docs/KB/cli_reference.md
+++ b/docs/KB/cli_reference.md
@@ -76,7 +76,7 @@
 | --bpm | int | None | Ustaw tempo utworu (beats per minute) |
 | --beats-per-panel | float | 2.0 | Ile beatów na panel |
 | --beats-travel | float | 0.5 | Ile beatów przejazdu |
-| --readability-ms | int | 1400 | Minimalna ekspozycja panelu (ms) |
+| --readability-ms | int | 1400 | Minimalna ekspozycja panelu (ms, min 1400) |
 | --min-dwell | float | 1.0 | Minimalny czas zatrzymania (s) |
 | --max-dwell | float | 1.8 | Maksymalny czas zatrzymania (s) |
 | --settle-min | float | 0.12 | Minimalny czas settle (s) |

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -16,6 +16,7 @@ from .bin_config import resolve_imagemagick, resolve_tesseract
 from .builder import make_filmstrip, _export_profile, _fit_audio_clip
 from .layers import shadow_cache_stats
 from .ocr import verify_tesseract_available
+from .validate import validate_args
 
 
 def _page_scale_type(x: str) -> float:
@@ -637,6 +638,11 @@ def main(argv: list[str] | None = None) -> None:
         np.random.seed(args.seed)
         logging.info("deterministic build seed=%s", args.seed)
     if args.validate:
+        errs = validate_args(args)
+        if errs:
+            for e in errs:
+                print(f"validation error: {e}", file=sys.stderr)
+            raise SystemExit(1)
         return
     target_size = (1080, 1920)
     if args.size:

--- a/ken_burns_reel/validate.py
+++ b/ken_burns_reel/validate.py
@@ -1,0 +1,28 @@
+"""Argument validation helpers for ken_burns_reel CLI."""
+from __future__ import annotations
+
+from argparse import Namespace
+from typing import List
+
+MIN_READ = 1.4
+
+
+def validate_args(args: Namespace) -> List[str]:
+    """Validate parsed CLI arguments.
+
+    Returns a list of human readable error messages. The caller should abort
+    if the list is non-empty.
+    """
+    min_read = max(MIN_READ, args.readability_ms / 1000.0)
+    errors: List[str] = []
+    if args.dwell < min_read:
+        errors.append(f"--dwell {args.dwell:.2f}s < min_read {min_read:.2f}s")
+    if args.min_dwell < min_read:
+        errors.append(f"--min-dwell {args.min_dwell:.2f}s < min_read {min_read:.2f}s")
+    if args.bpm:
+        beat = 60.0 / args.bpm
+        if args.beats_per_panel * beat < min_read:
+            errors.append(
+                "--beats-per-panel with --bpm shortens dwell below min_read"
+            )
+    return errors

--- a/tests/overlay/test_min_read.py
+++ b/tests/overlay/test_min_read.py
@@ -1,0 +1,36 @@
+import logging
+import numpy as np
+import pytest
+from PIL import Image
+
+cv2 = pytest.importorskip("cv2")
+
+from ken_burns_reel.panels import export_panels
+from ken_burns_reel.builder import make_panels_overlay_sequence
+
+
+def _make_page(tmp_path, cv2):
+    arr = np.full((100, 200, 3), 255, dtype=np.uint8)
+    cv2.rectangle(arr, (10, 10), (90, 90), (0, 0, 0), -1)
+    cv2.rectangle(arr, (110, 10), (190, 90), (0, 0, 0), -1)
+    p = tmp_path / "page.png"
+    Image.fromarray(arr).save(p)
+    return p
+
+
+def test_overlay_warns_and_clamps_min_read(tmp_path, caplog):
+    page = _make_page(tmp_path, cv2)
+    mask_dir = tmp_path / "mask" / "page_0001"
+    export_panels(str(page), str(mask_dir), mode="mask", bleed=0, tight_border=0, feather=1)
+    caplog.set_level(logging.WARNING)
+    clip = make_panels_overlay_sequence(
+        [str(page)],
+        str(tmp_path / "mask"),
+        target_size=(300, 450),
+        dwell=1.0,
+        dwell_scale=0.5,
+        dwell_mode="each",
+        readability_ms=1400,
+    )
+    assert "min_read" in caplog.text
+    assert clip.duration >= 1.4

--- a/tests/test_validate_main.py
+++ b/tests/test_validate_main.py
@@ -1,0 +1,25 @@
+import pytest
+
+cv2 = pytest.importorskip("cv2")
+from ken_burns_reel import __main__ as kb_main
+
+
+def test_validate_rejects_short_dwell(tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        kb_main.main([str(tmp_path), "--validate", "--dwell", "1.0"])
+    err = capsys.readouterr().err
+    assert "--dwell" in err
+
+
+def test_validate_rejects_beats_per_panel(tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        kb_main.main([
+            str(tmp_path),
+            "--validate",
+            "--bpm",
+            "240",
+            "--beats-per-panel",
+            "0.5",
+        ])
+    err = capsys.readouterr().err
+    assert "--beats-per-panel" in err


### PR DESCRIPTION
## Summary
- add `validate.py` with guard against flags shortening segments below 1.4s
- enforce 1.4s readability in builders and warn when clamped
- document validation behaviour

## Testing
- `ruff check .` *(fails: Line too long, unused imports)*
- `mypy .` *(fails: many incompatible types and missing stubs)*
- `pytest -q` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a9c016a388321b10a32236580e65a