### PR TITLE
Default arc travel path and auto QA preset generator

### DIFF
--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -577,7 +577,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--bg-offset", type=float, default=0.0, help="Opóźnienie ruchu tła (s)")
     parser.add_argument("--fg-offset", type=float, default=0.0, help="Opóźnienie ruchu panelu (s)")
     parser.add_argument("--seed", type=int, default=0, help="Seed deterministycznego driftu")
-    parser.add_argument("--travel-path", choices=["linear", "arc"], default="linear", help="Tor przejazdu kamery")
+    parser.add_argument("--travel-path", choices=["linear", "arc"], default="arc", help="Tor przejazdu kamery")
     parser.add_argument("--deep-bottom-glow", type=float, default=0.0, help="Poświata od dołu (0..1)")
     parser.add_argument("--page-scale-overlay", type=_page_scale_type, default=1.0, help="Skala strony przy overlay")
     parser.add_argument("--bg-vignette", type=_parallax_type, default=0.15, help="Siła winiety tła")

--- a/ken_burns_reel/builder.py
+++ b/ken_burns_reel/builder.py
@@ -862,7 +862,7 @@ def make_panels_overlay_sequence(
     bg_offset: float = 0.0,
     fg_offset: float = 0.0,
     seed: int = 0,
-    travel_path: str = "linear",
+    travel_path: str = "arc",
     deep_bottom_glow: float = 0.0,
     look: str = "none",
     timing_profile: str = "free",

--- a/ken_burns_reel/validate.py
+++ b/ken_burns_reel/validate.py
@@ -25,4 +25,8 @@ def validate_args(args: Namespace) -> List[str]:
             errors.append(
                 "--beats-per-panel with --bpm shortens dwell below min_read"
             )
+    for name in ("parallax_bg", "parallax_fg"):
+        val = getattr(args, name, 0.0)
+        if val < 0.0 or val > 0.06:
+            errors.append(f"--{name.replace('_', '-')} out of range")
     return errors

--- a/tests/tools/test_autoqa.py
+++ b/tests/tools/test_autoqa.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import yaml
+
+from tools.autoqa import generate_fix
+
+
+def write_csv(tmp_path: Path, rows: list[str]) -> Path:
+    csv_path = tmp_path / "autovideo_diagnostics.csv"
+    csv_path.write_text("file,motion_score,letterbox_flag,dark_flag,length_outlier\n" + "\n".join(rows))
+    return csv_path
+
+
+def test_generate_fix(tmp_path):
+    csv_path = write_csv(
+        tmp_path,
+        [
+            "a.jpg,0.2,1,0,0",
+            "b.jpg,0.9,0,1,1",
+            "c.jpg,0.5,0,0,0",
+        ],
+    )
+    yaml_path = tmp_path / "fix.yaml"
+    mapping = generate_fix(csv_path, yaml_path)
+
+    with yaml_path.open() as fh:
+        data = yaml.safe_load(fh)
+
+    assert mapping == data
+    assert "a.jpg" in data
+    assert data["a.jpg"]["travel"] == 0.3
+    assert data["a.jpg"]["letterbox"] is True
+    assert data["b.jpg"]["transition-duration"] == 0.1
+    assert data["b.jpg"]["bg-tone-strength"] == 0.7
+    assert "c.jpg" not in data
+

--- a/tools/autoqa.py
+++ b/tools/autoqa.py
@@ -1,0 +1,116 @@
+"""Generate per-file overrides from autovideo diagnostics CSV.
+
+This script reads ``autovideo_diagnostics.csv`` and emits a YAML file
+(``autovideo_presets_fix.yaml``) with overrides to be applied during a
+subsequent render pass.  Each row in the CSV maps to a file and contains
+quality diagnostics that decide the overrides to write.
+
+The following columns are recognised:
+
+``file`` (or ``filename``/``path``)
+    Identifier of the asset.
+
+``motion_score``
+    Floating point score describing motion; low scores trigger stronger
+    movement, high scores reduce it.
+
+``letterbox_flag``
+    Boolean flag indicating the asset requires a letterbox.
+
+``dark_flag``
+    Boolean flag; when set the background is brightened and the foreground
+    glow increased.
+
+``length_outlier``
+    Boolean flag marking clips that were significantly longer/shorter than
+    expected; forces per-panel dwell values.
+
+The generated YAML maps file identifiers to dictionaries of CLI overrides.
+Numeric adjustments are expressed as floats; consumers are expected to apply
+them additively to their defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+
+
+def _truthy(val: str | None) -> bool:
+    return str(val).strip().lower() in {"1", "true", "yes"}
+
+
+def generate_fix(csv_path: Path, yaml_path: Path) -> Dict[str, Dict[str, Any]]:
+    """Read *csv_path* and write overrides to *yaml_path*.
+
+    Returns the generated mapping for convenience/testing.
+    """
+
+    with csv_path.open(newline="", encoding="utf8") as fh:
+        rows = list(csv.DictReader(fh))
+
+    fixes: Dict[str, Dict[str, Any]] = {}
+
+    for row in rows:
+        name = row.get("file") or row.get("filename") or row.get("path")
+        if not name:
+            continue
+        cfg: Dict[str, Any] = {}
+
+        try:
+            motion_score = float(row.get("motion_score", ""))
+        except ValueError:
+            motion_score = 0.0
+
+        if motion_score and motion_score < 0.4:
+            cfg.update({"travel": 0.3, "zoom-max": 0.08, "page-scale": -0.02, "dwell": -0.2})
+        elif motion_score and motion_score > 0.6:
+            cfg.update({"travel": -0.3, "transition-duration": 0.1, "page-scale": 0.02})
+
+        if _truthy(row.get("letterbox_flag")):
+            cfg["letterbox"] = True
+            cfg["page-scale"] = cfg.get("page-scale", 0.0) - 0.03
+
+        if _truthy(row.get("dark_flag")):
+            cfg["bg-tone-strength"] = 0.7
+            cfg["fg-glow"] = 0.08
+
+        if _truthy(row.get("length_outlier")):
+            cfg["min-dwell"] = 1.4
+            cfg["dwell-mode"] = "each"
+
+        if cfg:
+            fixes[name] = cfg
+
+    with yaml_path.open("w", encoding="utf8") as fh:
+        yaml.safe_dump(fixes, fh, sort_keys=True)
+
+    return fixes
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "csv_path",
+        nargs="?",
+        default="autovideo_diagnostics.csv",
+        help="Path to diagnostics CSV",
+    )
+    parser.add_argument(
+        "-o",
+        "--out",
+        default="autovideo_presets_fix.yaml",
+        help="Output YAML path",
+    )
+    args = parser.parse_args(argv)
+
+    generate_fix(Path(args.csv_path), Path(args.out))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+


### PR DESCRIPTION
## Summary
- default travel path to arc and validate parallax limits
- add script to convert diagnostics CSV into per-file preset fixes

## Testing
- `python -m pytest tests/tools/test_autoqa.py -q`
- `python -m pytest -q` *(fails: make_panels_overlay_sequence: no panels found, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689aa61bb1a0832182d2117bddb6ba24