### PR TITLE
feat(cli): clamp tight-border option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ python -m ken_burns_reel input_folder ^
   --transition-duration 0.3
 ```
 
+### Tight border mask erosion
+Adjust how much the mask edge is eroded when exporting panels:
+
+```bash
+python -m ken_burns_reel input_folder --tight-border 0   # no erosion
+python -m ken_burns_reel input_folder --tight-border 12  # 12px erosion
+```
+
 ### Speech bubble detection (2-page test)
 
 **PowerShell**

--- a/ken_burns_reel/__main__.py
+++ b/ken_burns_reel/__main__.py
@@ -47,6 +47,13 @@ def _clamp_nonneg_int(x: str) -> int:
     return max(0, int(x))
 
 
+def _tight_border_type(x: str) -> int:
+    v = int(x)
+    if not 0 <= v <= 100:
+        raise argparse.ArgumentTypeError("--tight-border must be 0-100")
+    return v
+
+
 def _zoom_max_type(x: str) -> float:
     v = float(x)
     if v < 1.0:
@@ -289,7 +296,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--limit-items", type=int, default=999, help="Limit liczby paneli w overlay")
-    parser.add_argument("--tight-border", type=int, default=1, help="Erozja konturu w eksporcie mask (px)")
+    parser.add_argument(
+        "--tight-border",
+        type=_tight_border_type,
+        default=1,
+        help="Erozja konturu w eksporcie mask (px)",
+    )
     parser.add_argument("--feather", type=int, default=1, help="Feather alpha w eksporcie mask (px)")
     parser.add_argument(
         "--roughen",

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 from ken_burns_reel import cli
+from ken_burns_reel.__main__ import parse_args
 
 
 def test_tight_border_parser():
@@ -14,6 +15,16 @@ def test_tight_border_out_of_range():
     parser = cli.build_parser()
     with pytest.raises(SystemExit):
         parser.parse_args(["--tight-border", "200"])
+
+
+def test_main_tight_border_parser():
+    args = parse_args([".", "--tight-border", "5", "--validate"])
+    assert args.tight_border == 5
+
+
+def test_main_tight_border_out_of_range():
+    with pytest.raises(SystemExit):
+        parse_args([".", "--tight-border", "-1"])
 
 
 def test_trans_dur_alias_warns(caplog):


### PR DESCRIPTION
## Summary
- validate `--tight-border` range in main CLI
- document mask erosion with example commands
- cover `--tight-border` parsing in tests

## Testing
- `ruff check .` (fails: unused imports, line too long, etc.)
- `mypy .` (fails: missing stubs for `yaml`, duplicate module `tools.autoqa`)
- `pytest -q` (fails: 11 failed, 41 passed, 12 skipped)
- `python -m ken_burns_reel . --dry-run` (fails: unrecognized arguments: --dry-run)


------
https://chatgpt.com/codex/tasks/task_e_689aa86257748321983a3db332446eae